### PR TITLE
Add SQLite query linter library

### DIFF
--- a/sqlite-query-linter/README.md
+++ b/sqlite-query-linter/README.md
@@ -1,0 +1,399 @@
+# SQLite Query Linter
+
+A Python library that wraps `sqlite3` to provide configurable linting rules for SQL queries. Catch common SQLite mistakes before they cause runtime errors.
+
+## Features
+
+- **Drop-in replacement for sqlite3**: Minimal code changes required
+- **Configurable rules**: Enable/disable rules or create custom ones
+- **Sensible defaults**: Catches common SQLite pitfalls out of the box
+- **Flexible severity levels**: ERROR (blocks execution), WARNING (notifies), INFO
+- **Multiple modes**: Strict mode, permissive mode, or audit-only mode
+- **Zero dependencies**: Only requires Python standard library (and pytest for testing)
+
+## Installation
+
+Simply copy `sqlite_linter.py` to your project:
+
+```bash
+cp sqlite_linter.py /path/to/your/project/
+```
+
+Or install in development mode:
+
+```bash
+pip install -e .
+```
+
+## Quick Start
+
+```python
+import sqlite_linter
+
+# Create a linting connection (drop-in replacement for sqlite3.connect)
+conn = sqlite_linter.connect(":memory:")
+
+# Create table and insert data
+conn.execute("CREATE TABLE products (id INTEGER, name TEXT, price REAL)")
+conn.execute("INSERT INTO products VALUES (1, 'Widget', 9.99)")
+
+# This works fine
+cursor = conn.execute("SELECT name, price FROM products")
+print(cursor.fetchall())
+
+# This raises LintError - STRING is not a valid SQLite type!
+try:
+    conn.execute("SELECT CAST(price AS STRING) FROM products")
+except sqlite_linter.LintError as e:
+    print(f"Error: {e}")
+    # Error: Invalid type 'STRING' in CAST. Did you mean 'TEXT'?
+```
+
+## Built-in Linting Rules
+
+### 1. InvalidCastTypeRule (ERROR)
+
+Catches invalid type names in CAST expressions.
+
+**Problem:**
+```sql
+SELECT CAST(price AS STRING) FROM products  -- ✗ STRING is invalid
+SELECT CAST(active AS BOOL) FROM users      -- ✗ BOOL is invalid
+```
+
+**Solution:**
+```sql
+SELECT CAST(price AS TEXT) FROM products    -- ✓ TEXT is correct
+SELECT CAST(active AS INTEGER) FROM users   -- ✓ INTEGER is correct
+```
+
+**Valid SQLite types:** TEXT, INTEGER, REAL, BLOB, NUMERIC (and their variants)
+
+### 2. InvalidFunctionRule (ERROR)
+
+Detects SQL functions from other databases that don't exist in SQLite.
+
+**Problem:**
+```sql
+SELECT CONCAT(first, last) FROM users  -- ✗ CONCAT doesn't exist
+SELECT LEN(name) FROM products         -- ✗ Use LENGTH instead
+SELECT GETDATE()                       -- ✗ Use CURRENT_TIMESTAMP
+```
+
+**Solution:**
+```sql
+SELECT first || ' ' || last FROM users  -- ✓ Use || operator
+SELECT LENGTH(name) FROM products       -- ✓ Correct function name
+SELECT CURRENT_TIMESTAMP                -- ✓ SQLite standard
+```
+
+### 3. SelectStarRule (WARNING)
+
+Warns about `SELECT *` queries which can be inefficient and fragile.
+
+```sql
+SELECT * FROM users  -- ⚠ Warning: Consider explicit columns
+SELECT id, name, email FROM users  -- ✓ Better
+```
+
+### 4. MissingWhereClauseRule (WARNING)
+
+Warns about UPDATE/DELETE without WHERE clauses.
+
+```sql
+DELETE FROM users         -- ⚠ Warning: Will delete ALL rows
+UPDATE users SET active=0 -- ⚠ Warning: Will update ALL rows
+
+DELETE FROM users WHERE id = 5              -- ✓ Safe
+UPDATE users SET active=0 WHERE id > 100    -- ✓ Safe
+DELETE FROM users WHERE 1=1                 -- ✓ Explicit "all rows"
+```
+
+### 5. DoubleQuotesForStringsRule (WARNING)
+
+Reminds you that double quotes are for identifiers, single quotes for strings.
+
+```sql
+SELECT * FROM users WHERE name = "John"   -- ⚠ Should use single quotes
+SELECT * FROM users WHERE name = 'John'   -- ✓ Correct
+SELECT "user name" FROM users             -- ✓ OK for identifiers with spaces
+```
+
+## Configuration
+
+### Custom Rule Selection
+
+Choose which rules to apply:
+
+```python
+from sqlite_linter import InvalidCastTypeRule, InvalidFunctionRule
+
+# Only check for type and function errors
+rules = [InvalidCastTypeRule(), InvalidFunctionRule()]
+conn = sqlite_linter.connect(":memory:", rules=rules)
+```
+
+### Severity Levels
+
+Control how strict the linting should be:
+
+```python
+# Default: Block on errors, allow warnings
+conn = sqlite_linter.connect(":memory:")
+
+# Strict mode: Block on both errors and warnings
+conn = sqlite_linter.connect(":memory:",
+                             raise_on_error=True,
+                             raise_on_warning=True)
+
+# Permissive mode: Never block, just track issues
+conn = sqlite_linter.connect(":memory:",
+                             raise_on_error=False,
+                             raise_on_warning=False)
+
+cursor = conn.cursor()
+cursor.execute("SELECT * FROM users")
+# Check what was found:
+for issue in cursor.last_issues:
+    print(f"{issue.level}: {issue.message}")
+```
+
+## Creating Custom Rules
+
+Extend the `LintRule` base class:
+
+```python
+from sqlite_linter import LintRule, LintLevel, LintIssue
+import re
+
+class NoSelectCountStarRule(LintRule):
+    """Warn about COUNT(*) - prefer COUNT(column_name)"""
+
+    def __init__(self):
+        super().__init__("no_count_star", LintLevel.WARNING)
+
+    def check(self, query: str) -> list[LintIssue]:
+        if re.search(r'COUNT\s*\(\s*\*\s*\)', query, re.IGNORECASE):
+            return [LintIssue(
+                level=self.level,
+                rule_name=self.name,
+                message="COUNT(*) can be slow. Consider COUNT(column_name) instead.",
+                query=query
+            )]
+        return []
+
+# Use your custom rule
+rules = sqlite_linter.LintingConnection._default_rules()
+rules.append(NoSelectCountStarRule())
+conn = sqlite_linter.connect(":memory:", rules=rules)
+```
+
+## API Reference
+
+### Functions
+
+**`sqlite_linter.connect(database, rules=None, raise_on_error=True, raise_on_warning=False, **kwargs)`**
+
+Creates a linting SQLite connection.
+
+- `database`: Database file path or ":memory:"
+- `rules`: List of LintRule objects (uses defaults if None)
+- `raise_on_error`: Raise LintError on ERROR-level issues (default: True)
+- `raise_on_warning`: Raise LintWarning on WARNING-level issues (default: False)
+- `**kwargs`: Passed to sqlite3.connect()
+
+Returns: `LintingConnection` instance
+
+### Classes
+
+**`LintingConnection`**
+
+Wrapper around `sqlite3.Connection` that creates linting cursors.
+
+Methods:
+- `cursor()`: Create a LintingCursor
+- `execute(sql, parameters=())`: Execute query with linting
+- `executemany(sql, seq_of_parameters)`: Execute multiple times
+- `executescript(sql_script)`: Execute SQL script
+- All other `sqlite3.Connection` methods are proxied
+
+**`LintingCursor`**
+
+Wrapper around `sqlite3.Cursor` that lints queries before execution.
+
+Properties:
+- `last_issues`: List of LintIssue objects from the last query
+
+Methods:
+- Same as `sqlite3.Cursor`
+
+**`LintRule`**
+
+Base class for creating custom linting rules.
+
+Methods to implement:
+- `check(query: str) -> list[LintIssue]`: Check query for issues
+
+**`LintIssue`**
+
+Represents a linting issue.
+
+Properties:
+- `level`: LintLevel (ERROR, WARNING, INFO)
+- `rule_name`: Name of the rule that found this issue
+- `message`: Human-readable description
+- `query`: The SQL query that has the issue
+- `position`: Optional character position in query
+
+### Exceptions
+
+**`LintError`**
+
+Raised when a query fails ERROR-level linting (if `raise_on_error=True`).
+
+Properties:
+- `issues`: List of LintIssue objects
+
+**`LintWarning`**
+
+Raised when a query fails WARNING-level linting (if `raise_on_warning=True`).
+
+Properties:
+- `issues`: List of LintIssue objects
+
+## Use Cases
+
+### Development Mode
+
+Catch mistakes early during development:
+
+```python
+conn = sqlite_linter.connect("app.db")
+# Strict checking helps catch bugs
+```
+
+### Testing
+
+Ensure test queries use proper SQLite syntax:
+
+```python
+def test_user_query():
+    conn = sqlite_linter.connect(":memory:")
+    # Any bad SQL will fail the test
+    conn.execute("SELECT id, name FROM users WHERE active = 1")
+```
+
+### Code Migration
+
+Find incompatible SQL when migrating from other databases:
+
+```python
+# Audit mode - find all issues without blocking
+conn = sqlite_linter.connect("legacy.db",
+                             raise_on_error=False,
+                             raise_on_warning=False)
+
+cursor = conn.cursor()
+for query in legacy_queries:
+    cursor.execute(query)
+    if cursor.last_issues:
+        print(f"Query needs fixing: {query}")
+        for issue in cursor.last_issues:
+            print(f"  - {issue.message}")
+```
+
+### Production Monitoring
+
+Track query quality in production (non-blocking):
+
+```python
+import logging
+
+conn = sqlite_linter.connect("prod.db",
+                             raise_on_error=False,
+                             raise_on_warning=False)
+
+cursor = conn.cursor()
+cursor.execute(user_query)
+
+for issue in cursor.last_issues:
+    if issue.level == LintLevel.ERROR:
+        logging.error(f"Bad query: {issue.message}")
+    elif issue.level == LintLevel.WARNING:
+        logging.warning(f"Query warning: {issue.message}")
+```
+
+## Running Tests
+
+```bash
+pytest test_sqlite_linter.py -v
+```
+
+All 37 tests should pass:
+
+```
+============================== 37 passed in 0.25s ===============================
+```
+
+## Running the Demo
+
+See the library in action:
+
+```bash
+python demo.py
+```
+
+## Implementation Notes
+
+- **Parser-free**: Uses regex pattern matching for simplicity and speed
+- **Non-intrusive**: Wraps sqlite3 without modifying queries or results
+- **Lazy evaluation**: Rules only run when queries are executed
+- **Stateless rules**: Each rule is independent and reusable
+- **Thread-safe**: Each connection has its own rule set
+
+## Limitations
+
+- Regex-based parsing may miss some edge cases (a full SQL parser would be more accurate)
+- Dynamic SQL built at runtime can't be fully analyzed
+- Comments within SQL may confuse some rules
+- Multi-statement scripts are checked as a single unit
+
+## Future Enhancements
+
+Possible additions:
+
+- Index usage recommendations
+- Query performance hints
+- Schema validation rules
+- SQL injection pattern detection
+- More comprehensive type checking
+- Integration with SQL formatters
+- VSCode/IDE integration
+
+## License
+
+MIT License - feel free to use in your projects!
+
+## Contributing
+
+To add a new rule:
+
+1. Create a class inheriting from `LintRule`
+2. Implement the `check(query)` method
+3. Add tests in `test_sqlite_linter.py`
+4. Add to default rules in `_default_rules()` if appropriate
+
+## Example Projects
+
+This library is particularly useful for:
+
+- Web applications using SQLite
+- Data science projects with SQLite databases
+- Testing frameworks that verify SQL correctness
+- Database migration tools
+- Educational projects teaching SQL
+- Code quality tools and linters
+
+## Credits
+
+Created as a demonstration of configurable SQL linting for Python's sqlite3 module.

--- a/sqlite-query-linter/demo.py
+++ b/sqlite-query-linter/demo.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Demo script showing sqlite_linter in action
+"""
+
+import sqlite_linter
+from sqlite_linter import LintError, LintWarning
+
+
+def demo_basic_usage():
+    """Basic usage example"""
+    print("=" * 60)
+    print("DEMO 1: Basic Usage")
+    print("=" * 60)
+
+    # Create a linting connection
+    conn = sqlite_linter.connect(":memory:")
+
+    # Create a table
+    conn.execute("""
+        CREATE TABLE products (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            price REAL
+        )
+    """)
+
+    # Insert some data
+    conn.execute("INSERT INTO products (name, price) VALUES ('Widget', 9.99)")
+    conn.execute("INSERT INTO products (name, price) VALUES ('Gadget', 19.99)")
+
+    # Valid query works fine
+    print("\n✓ Valid query:")
+    print("  SELECT name, price FROM products")
+    cursor = conn.execute("SELECT name, price FROM products")
+    for row in cursor:
+        print(f"    {row}")
+
+    # Invalid CAST is caught
+    print("\n✗ Invalid query (STRING instead of TEXT):")
+    print("  SELECT CAST(price AS STRING) FROM products")
+    try:
+        conn.execute("SELECT CAST(price AS STRING) FROM products")
+    except LintError as e:
+        print(f"    LintError: {e}")
+
+    conn.close()
+
+
+def demo_warning_levels():
+    """Demo showing warning vs error levels"""
+    print("\n" + "=" * 60)
+    print("DEMO 2: Warning Levels")
+    print("=" * 60)
+
+    # By default, warnings don't block execution
+    conn = sqlite_linter.connect(":memory:", raise_on_warning=False)
+    conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+
+    print("\n⚠ Warning (but allowed):")
+    print("  SELECT * FROM users")
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM users")
+    print(f"    Query executed, {len(cursor.last_issues)} warnings found:")
+    for issue in cursor.last_issues:
+        print(f"      - {issue.message}")
+
+    # Can configure to block on warnings
+    print("\n⚠ Same query with raise_on_warning=True:")
+    conn2 = sqlite_linter.connect(":memory:", raise_on_warning=True)
+    conn2.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+    try:
+        conn2.execute("SELECT * FROM users")
+    except LintWarning as e:
+        print(f"    LintWarning: {e}")
+
+    conn.close()
+    conn2.close()
+
+
+def demo_custom_rules():
+    """Demo showing custom rule configuration"""
+    print("\n" + "=" * 60)
+    print("DEMO 3: Custom Rules")
+    print("=" * 60)
+
+    # Only check for CAST errors
+    from sqlite_linter import InvalidCastTypeRule
+    rules = [InvalidCastTypeRule()]
+
+    conn = sqlite_linter.connect(":memory:", rules=rules)
+    conn.execute("CREATE TABLE data (value INTEGER)")
+
+    print("\n✓ SELECT * is allowed (SelectStarRule not included):")
+    print("  SELECT * FROM data")
+    cursor = conn.execute("SELECT * FROM data")
+    print("    Query executed successfully")
+
+    print("\n✗ Invalid CAST still caught:")
+    print("  SELECT CAST(value AS STRING) FROM data")
+    try:
+        conn.execute("SELECT CAST(value AS STRING) FROM data")
+    except LintError as e:
+        print(f"    LintError: {e}")
+
+    conn.close()
+
+
+def demo_dangerous_operations():
+    """Demo showing detection of dangerous operations"""
+    print("\n" + "=" * 60)
+    print("DEMO 4: Dangerous Operations")
+    print("=" * 60)
+
+    conn = sqlite_linter.connect(":memory:", raise_on_warning=False)
+    conn.execute("CREATE TABLE accounts (id INTEGER, balance REAL)")
+    conn.execute("INSERT INTO accounts VALUES (1, 100.0)")
+    conn.execute("INSERT INTO accounts VALUES (2, 200.0)")
+
+    print("\n⚠ DELETE without WHERE:")
+    print("  DELETE FROM accounts")
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM accounts")
+    print(f"    Warning: {cursor.last_issues[0].message}")
+
+    conn.close()
+
+
+def demo_invalid_functions():
+    """Demo showing invalid function detection"""
+    print("\n" + "=" * 60)
+    print("DEMO 5: Invalid Functions")
+    print("=" * 60)
+
+    conn = sqlite_linter.connect(":memory:")
+    conn.execute("CREATE TABLE users (first_name TEXT, last_name TEXT)")
+
+    print("\n✗ Invalid function CONCAT:")
+    print("  SELECT CONCAT(first_name, last_name) FROM users")
+    try:
+        conn.execute("SELECT CONCAT(first_name, last_name) FROM users")
+    except LintError as e:
+        print(f"    LintError: {e}")
+
+    print("\n✓ Correct SQLite syntax:")
+    print("  SELECT first_name || ' ' || last_name FROM users")
+    cursor = conn.execute("SELECT first_name || ' ' || last_name FROM users")
+    print("    Query executed successfully")
+
+    conn.close()
+
+
+def demo_permissive_mode():
+    """Demo showing permissive mode for checking without blocking"""
+    print("\n" + "=" * 60)
+    print("DEMO 6: Permissive Mode (Audit Only)")
+    print("=" * 60)
+
+    # Don't block on any issues, just track them
+    conn = sqlite_linter.connect(":memory:",
+                                 raise_on_error=False,
+                                 raise_on_warning=False)
+    conn.execute("CREATE TABLE test (value TEXT)")
+
+    print("\nRunning problematic queries without blocking:\n")
+
+    queries = [
+        "SELECT * FROM test",
+        "SELECT CAST(value AS STRING) FROM test",
+        "DELETE FROM test",
+    ]
+
+    for query in queries:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(query)
+            if cursor.last_issues:
+                print(f"Query: {query}")
+                for issue in cursor.last_issues:
+                    icon = "✗" if issue.level.value == "error" else "⚠"
+                    print(f"  {icon} [{issue.level.value.upper()}] {issue.message}")
+            else:
+                print(f"Query: {query}")
+                print("  ✓ No issues")
+        except Exception as e:
+            print(f"Query: {query}")
+            print(f"  ✗ SQLite error: {e}")
+        print()
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    demo_basic_usage()
+    demo_warning_levels()
+    demo_custom_rules()
+    demo_dangerous_operations()
+    demo_invalid_functions()
+    demo_permissive_mode()
+
+    print("\n" + "=" * 60)
+    print("All demos completed!")
+    print("=" * 60)

--- a/sqlite-query-linter/notes.md
+++ b/sqlite-query-linter/notes.md
@@ -1,0 +1,211 @@
+# SQLite Query Linter - Development Notes
+
+## Project Goal
+Build a Python library that wraps sqlite3 and provides configurable linting rules for SQL queries before execution.
+
+## Initial Planning
+
+### Architecture Design
+- Wrapper around sqlite3 Connection and Cursor
+- Rule-based system where each rule can analyze SQL queries
+- Rules should be composable and configurable
+- Should catch common SQLite mistakes before execution
+
+### Example Rules to Implement
+1. Invalid type names in CAST expressions (STRING vs TEXT, etc.)
+2. Dangerous queries (SELECT * without WHERE on large tables)
+3. Invalid SQLite keywords or syntax
+4. Ambiguous column references
+5. Missing indices warnings
+
+### Development Steps
+1. Create base linting framework
+2. Implement rule system
+3. Add default rules
+4. Write tests
+5. Document API
+
+## Session Log
+
+### Session Start
+Starting implementation of sqlite-query-linter library...
+
+### Architecture Decisions
+
+1. **Wrapper Pattern**: Chose to wrap sqlite3.Connection and sqlite3.Cursor rather than subclass
+   - Allows easy delegation of methods
+   - Non-intrusive to existing sqlite3 behavior
+   - Clean separation between linting and execution
+
+2. **Rule-Based System**: Created LintRule base class
+   - Each rule is independent and composable
+   - Easy to add new rules
+   - Configurable at connection time
+
+3. **Severity Levels**: Implemented three levels (ERROR, WARNING, INFO)
+   - ERROR: Should block execution (invalid SQL)
+   - WARNING: May execute but not recommended
+   - INFO: Informational messages
+   - Configurable blocking behavior
+
+4. **Regex vs Parser**: Used regex for pattern matching
+   - Simpler implementation
+   - Good enough for common cases
+   - Faster than full SQL parser
+   - May miss some edge cases but acceptable tradeoff
+
+### Implementation Details
+
+#### Core Classes
+
+1. **LintRule**: Base class for all rules
+   - `check(query)` method returns list of LintIssue objects
+   - Each rule has a name and severity level
+
+2. **LintIssue**: Data class for issues
+   - Contains level, rule_name, message, query, optional position
+   - Simple and clear representation
+
+3. **LintingCursor**: Wraps sqlite3.Cursor
+   - Intercepts execute(), executemany(), executescript()
+   - Runs all rules before query execution
+   - Tracks issues in `last_issues` attribute
+   - Delegates all other methods to underlying cursor
+
+4. **LintingConnection**: Wraps sqlite3.Connection
+   - Creates LintingCursor instances
+   - Manages rule configuration
+   - Provides convenience execute methods
+   - Delegates all other methods to underlying connection
+
+#### Default Rules Implemented
+
+1. **InvalidCastTypeRule**: Catches CAST(x AS STRING) and similar
+   - Maps common mistakes: STRING→TEXT, BOOL→INTEGER, etc.
+   - Knows all valid SQLite type affinities
+   - Clear error messages with suggestions
+
+2. **InvalidFunctionRule**: Detects non-SQLite functions
+   - CONCAT → use || operator
+   - LEN → use LENGTH()
+   - ISNULL → use IFNULL() or COALESCE()
+   - GETDATE/NOW → use CURRENT_TIMESTAMP
+
+3. **SelectStarRule**: Warns about SELECT *
+   - Common code smell
+   - Fragile to schema changes
+   - Can be inefficient
+
+4. **MissingWhereClauseRule**: Catches DELETE/UPDATE without WHERE
+   - Prevents accidental mass operations
+   - Suggests adding WHERE 1=1 if intentional
+
+5. **DoubleQuotesForStringsRule**: Reminds about SQLite quoting rules
+   - Single quotes for string literals
+   - Double quotes for identifiers
+
+### Testing Strategy
+
+Created comprehensive test suite with 37 tests:
+
+1. **Unit tests** for each rule individually
+   - Test positive cases (catches bad SQL)
+   - Test negative cases (allows good SQL)
+   - Test edge cases (case sensitivity, multiple issues)
+
+2. **Integration tests** for LintingConnection
+   - Test blocking behavior
+   - Test warning vs error handling
+   - Test custom rule configuration
+   - Test cursor and connection methods
+
+3. **End-to-end tests** for workflows
+   - Typical usage patterns
+   - Selective linting
+   - Permissive mode
+
+All tests pass successfully!
+
+### Demo Script
+
+Created `demo.py` showing:
+1. Basic usage
+2. Warning vs error levels
+3. Custom rule configuration
+4. Dangerous operations detection
+5. Invalid function detection
+6. Permissive (audit) mode
+
+### Documentation
+
+Created comprehensive README.md with:
+- Quick start guide
+- Detailed rule documentation
+- Configuration examples
+- Custom rule creation guide
+- API reference
+- Use cases and examples
+- Running tests and demos
+
+### Key Learnings
+
+1. **SQLite Type System**: SQLite uses "type affinity" not strict types
+   - Five affinities: TEXT, NUMERIC, INTEGER, REAL, BLOB
+   - Many type names map to these (VARCHAR→TEXT, INT→INTEGER, etc.)
+   - Common mistake: using types from other databases (STRING, BOOL)
+
+2. **SQLite Function Differences**: Many SQL functions differ between databases
+   - No CONCAT() - use || instead
+   - LENGTH() not LEN()
+   - No GETDATE() - use datetime() or CURRENT_TIMESTAMP
+
+3. **Quote Rules**: SQLite follows SQL standard strictly
+   - Single quotes for string literals: 'text'
+   - Double quotes for identifiers: "column name"
+   - Backticks also work for identifiers (MySQL compatibility)
+
+4. **Wrapper Pattern Benefits**:
+   - Clean code organization
+   - Easy to maintain
+   - Non-breaking changes to sqlite3
+   - Clear separation of concerns
+
+### Files Created
+
+- `sqlite_linter.py`: Main library (400+ lines)
+- `test_sqlite_linter.py`: Test suite (400+ lines, 37 tests)
+- `demo.py`: Interactive demonstration
+- `README.md`: Comprehensive documentation
+- `notes.md`: This file
+
+### Test Results
+
+```
+============================= test session starts ==============================
+37 passed in 0.25s
+```
+
+### Demo Output
+
+All 6 demos run successfully showing:
+- Error detection and blocking
+- Warning detection and optional blocking
+- Custom rule configuration
+- Dangerous operation detection
+- Invalid function detection
+- Permissive audit mode
+
+### Conclusion
+
+Successfully created a working, tested, documented SQLite query linter with:
+- ✅ Configurable rule system
+- ✅ 5 sensible default rules
+- ✅ Flexible severity levels
+- ✅ Comprehensive tests (37 passing)
+- ✅ Clear documentation
+- ✅ Working demo
+- ✅ Drop-in replacement for sqlite3
+
+The library successfully catches the example from the spec:
+`SELECT CAST(bar AS STRING) AS baz FROM foo`
+→ Error: "Invalid type 'STRING' in CAST. Did you mean 'TEXT'?"

--- a/sqlite-query-linter/requirements.txt
+++ b/sqlite-query-linter/requirements.txt
@@ -1,0 +1,4 @@
+# No runtime dependencies - uses only Python standard library
+
+# Development dependencies
+pytest>=7.0.0

--- a/sqlite-query-linter/sqlite_linter.py
+++ b/sqlite-query-linter/sqlite_linter.py
@@ -1,0 +1,373 @@
+"""
+SQLite Query Linter
+
+A wrapper around sqlite3 that provides configurable linting rules for SQL queries.
+Helps catch common mistakes and bad practices before executing queries.
+"""
+
+import sqlite3
+import re
+from typing import List, Optional, Tuple, Any
+from dataclasses import dataclass
+from enum import Enum
+
+
+class LintLevel(Enum):
+    """Severity level for linting issues"""
+    ERROR = "error"      # Query should not be executed
+    WARNING = "warning"  # Query has issues but can execute
+    INFO = "info"        # Informational message
+
+
+@dataclass
+class LintIssue:
+    """Represents a linting issue found in a query"""
+    level: LintLevel
+    rule_name: str
+    message: str
+    query: str
+    position: Optional[int] = None  # Character position in query if applicable
+
+
+class LintRule:
+    """Base class for linting rules"""
+
+    def __init__(self, name: str, level: LintLevel = LintLevel.ERROR):
+        self.name = name
+        self.level = level
+
+    def check(self, query: str) -> List[LintIssue]:
+        """
+        Check a query for issues.
+
+        Args:
+            query: SQL query string to check
+
+        Returns:
+            List of LintIssue objects found (empty if no issues)
+        """
+        raise NotImplementedError("Subclasses must implement check()")
+
+
+class InvalidCastTypeRule(LintRule):
+    """Check for invalid type names in CAST expressions"""
+
+    # Valid SQLite affinity types
+    VALID_TYPES = {
+        'INTEGER', 'INT', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT',
+        'UNSIGNED BIG INT', 'INT2', 'INT8',
+        'TEXT', 'CLOB', 'CHARACTER', 'VARCHAR', 'VARYING CHARACTER',
+        'NCHAR', 'NATIVE CHARACTER', 'NVARCHAR',
+        'REAL', 'DOUBLE', 'DOUBLE PRECISION', 'FLOAT',
+        'NUMERIC', 'DECIMAL', 'BOOLEAN', 'DATE', 'DATETIME',
+        'BLOB'
+    }
+
+    # Common mistakes
+    INVALID_MAPPINGS = {
+        'STRING': 'TEXT',
+        'STR': 'TEXT',
+        'LONG': 'INTEGER',
+        'BOOL': 'INTEGER',
+    }
+
+    def __init__(self):
+        super().__init__("invalid_cast_type", LintLevel.ERROR)
+
+    def check(self, query: str) -> List[LintIssue]:
+        issues = []
+        # Pattern to match CAST expressions
+        cast_pattern = r'CAST\s*\(\s*[^)]+\s+AS\s+([A-Za-z][A-Za-z0-9\s]*)\s*\)'
+
+        for match in re.finditer(cast_pattern, query, re.IGNORECASE):
+            type_name = match.group(1).strip().upper()
+
+            # Check if it's a valid type
+            if type_name not in self.VALID_TYPES:
+                suggestion = self.INVALID_MAPPINGS.get(type_name)
+                if suggestion:
+                    message = f"Invalid type '{type_name}' in CAST. Did you mean '{suggestion}'?"
+                else:
+                    message = f"Invalid type '{type_name}' in CAST. Valid types include: TEXT, INTEGER, REAL, BLOB, NUMERIC"
+
+                issues.append(LintIssue(
+                    level=self.level,
+                    rule_name=self.name,
+                    message=message,
+                    query=query,
+                    position=match.start()
+                ))
+
+        return issues
+
+
+class SelectStarRule(LintRule):
+    """Warn about SELECT * queries"""
+
+    def __init__(self, level: LintLevel = LintLevel.WARNING):
+        super().__init__("select_star", level)
+
+    def check(self, query: str) -> List[LintIssue]:
+        issues = []
+        # Look for SELECT * patterns
+        if re.search(r'\bSELECT\s+\*\s+FROM\b', query, re.IGNORECASE):
+            issues.append(LintIssue(
+                level=self.level,
+                rule_name=self.name,
+                message="SELECT * can be inefficient and fragile. Consider specifying columns explicitly.",
+                query=query
+            ))
+        return issues
+
+
+class MissingWhereClauseRule(LintRule):
+    """Warn about UPDATE/DELETE without WHERE clause"""
+
+    def __init__(self, level: LintLevel = LintLevel.WARNING):
+        super().__init__("missing_where", level)
+
+    def check(self, query: str) -> List[LintIssue]:
+        issues = []
+
+        # Check DELETE without WHERE
+        if re.search(r'\bDELETE\s+FROM\s+\w+\s*(?:;|$)', query, re.IGNORECASE):
+            issues.append(LintIssue(
+                level=self.level,
+                rule_name=self.name,
+                message="DELETE without WHERE clause will remove all rows. Add WHERE clause or use DELETE FROM table WHERE 1=1 to confirm.",
+                query=query
+            ))
+
+        # Check UPDATE without WHERE
+        if re.search(r'\bUPDATE\s+\w+\s+SET\s+.+?(?:;|$)(?!.*WHERE)', query, re.IGNORECASE | re.DOTALL):
+            if 'WHERE' not in query.upper():
+                issues.append(LintIssue(
+                    level=self.level,
+                    rule_name=self.name,
+                    message="UPDATE without WHERE clause will modify all rows. Add WHERE clause or use WHERE 1=1 to confirm.",
+                    query=query
+                ))
+
+        return issues
+
+
+class InvalidFunctionRule(LintRule):
+    """Check for common function name mistakes"""
+
+    INVALID_FUNCTIONS = {
+        'CONCAT': 'Use || operator instead',
+        'LEN': 'Use LENGTH() instead',
+        'ISNULL': 'Use IFNULL() or COALESCE() instead',
+        'GETDATE': 'Use CURRENT_TIMESTAMP or datetime() instead',
+        'NOW': 'Use CURRENT_TIMESTAMP or datetime() instead',
+    }
+
+    def __init__(self):
+        super().__init__("invalid_function", LintLevel.ERROR)
+
+    def check(self, query: str) -> List[LintIssue]:
+        issues = []
+
+        for func, suggestion in self.INVALID_FUNCTIONS.items():
+            pattern = r'\b' + func + r'\s*\('
+            if re.search(pattern, query, re.IGNORECASE):
+                issues.append(LintIssue(
+                    level=self.level,
+                    rule_name=self.name,
+                    message=f"Invalid function {func}(). {suggestion}",
+                    query=query
+                ))
+
+        return issues
+
+
+class DoubleQuotesForStringsRule(LintRule):
+    """Warn about using double quotes for string literals"""
+
+    def __init__(self, level: LintLevel = LintLevel.WARNING):
+        super().__init__("double_quotes_strings", level)
+
+    def check(self, query: str) -> List[LintIssue]:
+        issues = []
+
+        # Look for double-quoted strings (not identifiers)
+        # This is a simplification - a full parser would be more accurate
+        # Double quotes are for identifiers in SQLite, single quotes for strings
+        pattern = r'"[^"]*"'
+        matches = list(re.finditer(pattern, query))
+
+        if matches and not re.search(r'\bCREATE\b', query, re.IGNORECASE):
+            issues.append(LintIssue(
+                level=self.level,
+                rule_name=self.name,
+                message="Use single quotes for string literals. Double quotes are for identifiers in SQLite.",
+                query=query
+            ))
+
+        return issues
+
+
+class LintingCursor:
+    """Cursor wrapper that lints queries before execution"""
+
+    def __init__(self, cursor: sqlite3.Cursor, rules: List[LintRule],
+                 raise_on_error: bool = True, raise_on_warning: bool = False):
+        self._cursor = cursor
+        self._rules = rules
+        self._raise_on_error = raise_on_error
+        self._raise_on_warning = raise_on_warning
+        self.last_issues: List[LintIssue] = []
+
+    def _lint_query(self, query: str) -> List[LintIssue]:
+        """Run all linting rules on a query"""
+        all_issues = []
+        for rule in self._rules:
+            issues = rule.check(query)
+            all_issues.extend(issues)
+        return all_issues
+
+    def _check_and_raise(self, query: str):
+        """Lint query and raise exception if configured to do so"""
+        self.last_issues = self._lint_query(query)
+
+        errors = [i for i in self.last_issues if i.level == LintLevel.ERROR]
+        warnings = [i for i in self.last_issues if i.level == LintLevel.WARNING]
+
+        if errors and self._raise_on_error:
+            error_msgs = '\n'.join(f"  - {issue.message}" for issue in errors)
+            raise LintError(f"Query failed linting:\n{error_msgs}", errors)
+
+        if warnings and self._raise_on_warning:
+            warning_msgs = '\n'.join(f"  - {issue.message}" for issue in warnings)
+            raise LintWarning(f"Query has warnings:\n{warning_msgs}", warnings)
+
+    def execute(self, sql: str, parameters: tuple = ()):
+        """Execute query after linting"""
+        self._check_and_raise(sql)
+        return self._cursor.execute(sql, parameters)
+
+    def executemany(self, sql: str, seq_of_parameters):
+        """Execute query multiple times after linting"""
+        self._check_and_raise(sql)
+        return self._cursor.executemany(sql, seq_of_parameters)
+
+    def executescript(self, sql_script: str):
+        """Execute script after linting"""
+        self._check_and_raise(sql_script)
+        return self._cursor.executescript(sql_script)
+
+    # Delegate other cursor methods
+    def __getattr__(self, name):
+        return getattr(self._cursor, name)
+
+    def __iter__(self):
+        return iter(self._cursor)
+
+    def __next__(self):
+        return next(self._cursor)
+
+
+class LintingConnection:
+    """Connection wrapper that creates linting cursors"""
+
+    def __init__(self, database: str, rules: Optional[List[LintRule]] = None,
+                 raise_on_error: bool = True, raise_on_warning: bool = False,
+                 **kwargs):
+        """
+        Create a linting SQLite connection.
+
+        Args:
+            database: Database file path or ":memory:"
+            rules: List of linting rules to apply (uses defaults if None)
+            raise_on_error: Raise exception on ERROR level issues
+            raise_on_warning: Raise exception on WARNING level issues
+            **kwargs: Additional arguments passed to sqlite3.connect()
+        """
+        self._connection = sqlite3.connect(database, **kwargs)
+        self._rules = rules if rules is not None else self._default_rules()
+        self._raise_on_error = raise_on_error
+        self._raise_on_warning = raise_on_warning
+
+    @staticmethod
+    def _default_rules() -> List[LintRule]:
+        """Get default linting rules"""
+        return [
+            InvalidCastTypeRule(),
+            InvalidFunctionRule(),
+            SelectStarRule(LintLevel.WARNING),
+            MissingWhereClauseRule(LintLevel.WARNING),
+            DoubleQuotesForStringsRule(LintLevel.WARNING),
+        ]
+
+    def cursor(self) -> LintingCursor:
+        """Create a linting cursor"""
+        return LintingCursor(
+            self._connection.cursor(),
+            self._rules,
+            self._raise_on_error,
+            self._raise_on_warning
+        )
+
+    def execute(self, sql: str, parameters: tuple = ()):
+        """Execute query directly on connection"""
+        cursor = self.cursor()
+        return cursor.execute(sql, parameters)
+
+    def executemany(self, sql: str, seq_of_parameters):
+        """Execute query multiple times"""
+        cursor = self.cursor()
+        return cursor.executemany(sql, seq_of_parameters)
+
+    def executescript(self, sql_script: str):
+        """Execute SQL script"""
+        cursor = self.cursor()
+        return cursor.executescript(sql_script)
+
+    # Delegate other connection methods
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return self._connection.__exit__(exc_type, exc_val, exc_tb)
+
+
+class LintError(Exception):
+    """Exception raised when query fails linting with ERROR level"""
+    def __init__(self, message: str, issues: List[LintIssue]):
+        super().__init__(message)
+        self.issues = issues
+
+
+class LintWarning(Exception):
+    """Exception raised when query fails linting with WARNING level"""
+    def __init__(self, message: str, issues: List[LintIssue]):
+        super().__init__(message)
+        self.issues = issues
+
+
+def connect(database: str, rules: Optional[List[LintRule]] = None,
+            raise_on_error: bool = True, raise_on_warning: bool = False,
+            **kwargs) -> LintingConnection:
+    """
+    Create a linting SQLite connection (convenience function).
+
+    Args:
+        database: Database file path or ":memory:"
+        rules: List of linting rules to apply (uses defaults if None)
+        raise_on_error: Raise exception on ERROR level issues
+        raise_on_warning: Raise exception on WARNING level issues
+        **kwargs: Additional arguments passed to sqlite3.connect()
+
+    Returns:
+        LintingConnection instance
+
+    Example:
+        >>> import sqlite_linter
+        >>> conn = sqlite_linter.connect(":memory:")
+        >>> conn.execute("SELECT CAST(value AS STRING) FROM table")
+        LintError: Invalid type 'STRING' in CAST. Did you mean 'TEXT'?
+    """
+    return LintingConnection(database, rules, raise_on_error, raise_on_warning, **kwargs)

--- a/sqlite-query-linter/test_sqlite_linter.py
+++ b/sqlite-query-linter/test_sqlite_linter.py
@@ -1,0 +1,396 @@
+"""
+Comprehensive tests for sqlite_linter module
+"""
+
+import pytest
+import sqlite_linter
+from sqlite_linter import (
+    LintLevel, LintIssue, LintError, LintWarning,
+    InvalidCastTypeRule, SelectStarRule, MissingWhereClauseRule,
+    InvalidFunctionRule, DoubleQuotesForStringsRule
+)
+
+
+class TestInvalidCastTypeRule:
+    """Tests for invalid CAST type detection"""
+
+    def test_catches_string_type(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT CAST(bar AS STRING) AS baz FROM foo"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert issues[0].level == LintLevel.ERROR
+        assert "STRING" in issues[0].message
+        assert "TEXT" in issues[0].message
+
+    def test_catches_str_type(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT CAST(name AS STR) FROM users"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert "STR" in issues[0].message
+        assert "TEXT" in issues[0].message
+
+    def test_catches_bool_type(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT CAST(active AS BOOL) FROM accounts"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert "BOOL" in issues[0].message
+        assert "INTEGER" in issues[0].message
+
+    def test_allows_valid_text_type(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT CAST(bar AS TEXT) AS baz FROM foo"
+        issues = rule.check(query)
+
+        assert len(issues) == 0
+
+    def test_allows_valid_integer_type(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT CAST(value AS INTEGER) FROM data"
+        issues = rule.check(query)
+
+        assert len(issues) == 0
+
+    def test_allows_valid_real_type(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT CAST(price AS REAL) FROM products"
+        issues = rule.check(query)
+
+        assert len(issues) == 0
+
+    def test_case_insensitive(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT cast(bar as string) FROM foo"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+
+    def test_multiple_casts_in_query(self):
+        rule = InvalidCastTypeRule()
+        query = "SELECT CAST(a AS STRING), CAST(b AS TEXT), CAST(c AS BOOL) FROM t"
+        issues = rule.check(query)
+
+        assert len(issues) == 2  # STRING and BOOL are invalid
+
+
+class TestSelectStarRule:
+    """Tests for SELECT * detection"""
+
+    def test_catches_select_star(self):
+        rule = SelectStarRule()
+        query = "SELECT * FROM users"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert issues[0].level == LintLevel.WARNING
+        assert "SELECT *" in issues[0].message
+
+    def test_allows_explicit_columns(self):
+        rule = SelectStarRule()
+        query = "SELECT id, name FROM users"
+        issues = rule.check(query)
+
+        assert len(issues) == 0
+
+    def test_case_insensitive(self):
+        rule = SelectStarRule()
+        query = "select * from users"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+
+
+class TestMissingWhereClauseRule:
+    """Tests for missing WHERE clause detection"""
+
+    def test_catches_delete_without_where(self):
+        rule = MissingWhereClauseRule()
+        query = "DELETE FROM users"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert issues[0].level == LintLevel.WARNING
+        assert "DELETE" in issues[0].message
+        assert "WHERE" in issues[0].message
+
+    def test_catches_update_without_where(self):
+        rule = MissingWhereClauseRule()
+        query = "UPDATE users SET active = 0"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert "UPDATE" in issues[0].message
+
+    def test_allows_delete_with_where(self):
+        rule = MissingWhereClauseRule()
+        query = "DELETE FROM users WHERE id = 5"
+        issues = rule.check(query)
+
+        assert len(issues) == 0
+
+    def test_allows_update_with_where(self):
+        rule = MissingWhereClauseRule()
+        query = "UPDATE users SET active = 0 WHERE id > 100"
+        issues = rule.check(query)
+
+        assert len(issues) == 0
+
+
+class TestInvalidFunctionRule:
+    """Tests for invalid function detection"""
+
+    def test_catches_concat(self):
+        rule = InvalidFunctionRule()
+        query = "SELECT CONCAT(first_name, last_name) FROM users"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert "CONCAT" in issues[0].message
+        assert "||" in issues[0].message
+
+    def test_catches_len(self):
+        rule = InvalidFunctionRule()
+        query = "SELECT LEN(name) FROM products"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert "LEN" in issues[0].message
+        assert "LENGTH" in issues[0].message
+
+    def test_catches_isnull(self):
+        rule = InvalidFunctionRule()
+        query = "SELECT ISNULL(value, 0) FROM data"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert "ISNULL" in issues[0].message
+
+    def test_catches_getdate(self):
+        rule = InvalidFunctionRule()
+        query = "SELECT GETDATE()"
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert "GETDATE" in issues[0].message
+
+    def test_allows_valid_functions(self):
+        rule = InvalidFunctionRule()
+        query = "SELECT LENGTH(name), COALESCE(value, 0), CURRENT_TIMESTAMP FROM data"
+        issues = rule.check(query)
+
+        assert len(issues) == 0
+
+
+class TestDoubleQuotesForStringsRule:
+    """Tests for double quote detection"""
+
+    def test_catches_double_quotes(self):
+        rule = DoubleQuotesForStringsRule()
+        query = 'SELECT * FROM users WHERE name = "John"'
+        issues = rule.check(query)
+
+        assert len(issues) == 1
+        assert issues[0].level == LintLevel.WARNING
+        assert "single quotes" in issues[0].message.lower()
+
+
+class TestLintingConnection:
+    """Integration tests for LintingConnection"""
+
+    def test_connection_creation(self):
+        conn = sqlite_linter.connect(":memory:")
+        assert conn is not None
+
+    def test_blocks_invalid_cast(self):
+        conn = sqlite_linter.connect(":memory:")
+        conn.execute("CREATE TABLE foo (bar INTEGER)")
+
+        with pytest.raises(LintError) as exc_info:
+            conn.execute("SELECT CAST(bar AS STRING) FROM foo")
+
+        assert "STRING" in str(exc_info.value)
+        assert "TEXT" in str(exc_info.value)
+
+    def test_allows_valid_query(self):
+        conn = sqlite_linter.connect(":memory:")
+        conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+        conn.execute("INSERT INTO users VALUES (1, 'Alice')")
+
+        cursor = conn.execute("SELECT id, name FROM users")
+        results = cursor.fetchall()
+
+        assert len(results) == 1
+        assert results[0] == (1, 'Alice')
+
+    def test_valid_cast_works(self):
+        conn = sqlite_linter.connect(":memory:")
+        conn.execute("CREATE TABLE data (value INTEGER)")
+        conn.execute("INSERT INTO data VALUES (42)")
+
+        cursor = conn.execute("SELECT CAST(value AS TEXT) FROM data")
+        result = cursor.fetchone()
+
+        assert result[0] == '42'
+
+    def test_warning_doesnt_block_by_default(self):
+        conn = sqlite_linter.connect(":memory:", raise_on_warning=False)
+        conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+
+        # SELECT * should warn but not block
+        cursor = conn.execute("SELECT * FROM users")
+        assert cursor is not None
+
+    def test_warning_blocks_when_configured(self):
+        conn = sqlite_linter.connect(":memory:", raise_on_warning=True)
+        conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+
+        with pytest.raises(LintWarning):
+            conn.execute("SELECT * FROM users")
+
+    def test_can_disable_error_blocking(self):
+        conn = sqlite_linter.connect(":memory:", raise_on_error=False)
+        conn.execute("CREATE TABLE foo (bar INTEGER)")
+
+        # This should not raise even though it's an error
+        # (though it will fail at SQLite level)
+        try:
+            conn.execute("SELECT CAST(bar AS STRING) FROM foo")
+        except LintError:
+            pytest.fail("Should not raise LintError when raise_on_error=False")
+        except:
+            # Other errors (like from SQLite) are fine
+            pass
+
+    def test_custom_rules(self):
+        # Create connection with only one rule
+        rules = [InvalidCastTypeRule()]
+        conn = sqlite_linter.connect(":memory:", rules=rules)
+        conn.execute("CREATE TABLE users (name TEXT)")
+
+        # This should work because SELECT * rule is not included
+        cursor = conn.execute("SELECT * FROM users")
+        assert cursor is not None
+
+    def test_cursor_method(self):
+        conn = sqlite_linter.connect(":memory:")
+        cursor = conn.cursor()
+
+        cursor.execute("CREATE TABLE test (id INTEGER)")
+        cursor.execute("INSERT INTO test VALUES (1)")
+
+        cursor.execute("SELECT id FROM test")
+        assert cursor.fetchone() == (1,)
+
+    def test_executemany(self):
+        conn = sqlite_linter.connect(":memory:")
+        conn.execute("CREATE TABLE test (id INTEGER, value TEXT)")
+
+        data = [(1, 'a'), (2, 'b'), (3, 'c')]
+        conn.executemany("INSERT INTO test VALUES (?, ?)", data)
+
+        cursor = conn.execute("SELECT * FROM test ORDER BY id")
+        results = cursor.fetchall()
+        assert results == data
+
+    def test_context_manager(self):
+        with sqlite_linter.connect(":memory:") as conn:
+            conn.execute("CREATE TABLE test (id INTEGER)")
+            conn.execute("INSERT INTO test VALUES (1)")
+            conn.commit()
+
+    def test_last_issues_tracking(self):
+        conn = sqlite_linter.connect(":memory:", raise_on_warning=False)
+        conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM users")  # Should generate warning
+
+        assert len(cursor.last_issues) == 1
+        assert cursor.last_issues[0].level == LintLevel.WARNING
+
+    def test_multiple_issues(self):
+        conn = sqlite_linter.connect(":memory:", raise_on_error=True)
+        conn.execute("CREATE TABLE test (value TEXT)")
+
+        # Query with multiple issues
+        with pytest.raises(LintError) as exc_info:
+            conn.execute("SELECT CAST(value AS STRING), CONCAT('a', 'b') FROM test")
+
+        assert len(exc_info.value.issues) == 2
+
+
+class TestEndToEnd:
+    """End-to-end workflow tests"""
+
+    def test_typical_workflow(self):
+        # Connect with default rules
+        conn = sqlite_linter.connect(":memory:")
+
+        # Create schema
+        conn.execute("""
+            CREATE TABLE products (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                price REAL,
+                active INTEGER DEFAULT 1
+            )
+        """)
+
+        # Insert data
+        conn.execute("INSERT INTO products (name, price) VALUES (?, ?)",
+                    ("Widget", 9.99))
+
+        conn.executemany("INSERT INTO products (name, price) VALUES (?, ?)", [
+            ("Gadget", 19.99),
+            ("Doodad", 29.99),
+        ])
+
+        # Valid queries work fine
+        cursor = conn.execute("SELECT name, price FROM products WHERE active = 1")
+        results = cursor.fetchall()
+        assert len(results) == 3
+
+        # Invalid queries are blocked
+        with pytest.raises(LintError):
+            conn.execute("SELECT CAST(price AS STRING) FROM products")
+
+        conn.close()
+
+    def test_selective_linting(self):
+        # Only check for CAST errors
+        rules = [InvalidCastTypeRule()]
+        conn = sqlite_linter.connect(":memory:", rules=rules)
+
+        conn.execute("CREATE TABLE data (value INTEGER)")
+
+        # SELECT * is allowed now (no SelectStarRule)
+        cursor = conn.execute("SELECT * FROM data")
+        assert cursor is not None
+
+        # But invalid CAST still blocked
+        with pytest.raises(LintError):
+            conn.execute("SELECT CAST(value AS STRING) FROM data")
+
+    def test_permissive_mode(self):
+        # Warnings only, no blocking
+        conn = sqlite_linter.connect(":memory:",
+                                     raise_on_error=False,
+                                     raise_on_warning=False)
+
+        conn.execute("CREATE TABLE test (value TEXT)")
+
+        # Can check issues without blocking
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM test")  # Warning but allowed
+
+        assert len(cursor.last_issues) > 0
+        assert any(i.level == LintLevel.WARNING for i in cursor.last_issues)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implemented a Python library that wraps sqlite3 to provide configurable
linting rules for SQL queries. The library catches common SQLite mistakes
before execution, such as invalid CAST types (STRING vs TEXT), invalid
functions (CONCAT vs ||), and dangerous operations.

Features:
- Drop-in replacement for sqlite3.connect()
- 5 built-in linting rules (CAST types, functions, SELECT *, WHERE clauses, quotes)
- Configurable severity levels (ERROR, WARNING, INFO)
- Custom rule support
- Comprehensive test suite (37 tests, all passing)
- Full documentation and working demos

Files added:
- sqlite_linter.py: Main library implementation
- test_sqlite_linter.py: Comprehensive test suite
- demo.py: Interactive demonstration script
- README.md: Complete documentation with examples
- notes.md: Development notes and learnings
- requirements.txt: Development dependencies