### PR TITLE
Analysis: Days in 2024 with both Google and OpenAI tagged content

### DIFF
--- a/google-openai-days-2024/README.md
+++ b/google-openai-days-2024/README.md
@@ -1,5 +1,13 @@
 # Google and OpenAI Tagged Content Days in 2024
 
+## Task
+
+> Use this API to find every day within 2024 when there with at least one item of content tagged google and at least one other item of content tagged openai (or both tags on same item)
+>
+> Start with this to see the schema - be sure to consider content across entries and blogmarks and quotes and notes
+>
+> https://datasette.simonwillison.net/simonwillisonblog.json?sql=select+sql+from+sqlite_master&_shape=array
+
 ## Summary
 
 Analysis of Simon Willison's blog database to identify days in 2024 when content was tagged with both "google" and "openai" tags.

--- a/google-openai-days-2024/README.md
+++ b/google-openai-days-2024/README.md
@@ -1,0 +1,118 @@
+# Google and OpenAI Tagged Content Days in 2024
+
+## Summary
+
+Analysis of Simon Willison's blog database to identify days in 2024 when content was tagged with both "google" and "openai" tags.
+
+**Key Finding:** There were **18 days in 2024** with content tagged with both Google and OpenAI.
+
+## Methodology
+
+### Data Source
+- **Database:** https://datasette.simonwillison.net/simonwillisonblog
+- **Content Types Analyzed:**
+  - Blog entries (`blog_entry`)
+  - Blogmarks (`blog_blogmark`)
+  - Quotations (`blog_quotation`)
+  - Notes (`blog_note`)
+
+### Query Approach
+
+1. **UNION Query:** Combined all four content types with their associated tags
+2. **Filtering:** Limited to 2024 content tagged with either 'google' or 'openai'
+3. **Date Normalization:** Used SQLite's `date()` function to normalize TEXT dates
+4. **Aggregation:** Grouped results by date to identify days with both tags present
+
+### Implementation
+
+The analysis used a SQL query with a CTE (Common Table Expression) to union all tagged content:
+
+```sql
+WITH all_tagged_content AS (
+  SELECT date(e.created) as content_date, t.tag, 'entry' as content_type, ...
+  FROM blog_entry e
+  JOIN blog_entry_tags et ON e.id = et.entry_id
+  JOIN blog_tag t ON et.tag_id = t.id
+  WHERE t.tag IN ('google', 'openai') AND e.created LIKE '2024%'
+
+  UNION ALL
+  -- Similar queries for blogmarks, quotations, and notes
+)
+```
+
+Post-processing in Python grouped results by date and identified days with both tags.
+
+## Results
+
+### Statistics
+- **Total tagged items:** 178 content items with either 'google' or 'openai' tags in 2024
+- **Days with both tags:** 18 days
+- **Date range:** April 10, 2024 to December 31, 2024
+
+### Complete List of Days
+
+1. **2024-12-31** - Things we learned about LLMs in 2024 (tagged with both)
+2. **2024-12-20** - Multiple items including OpenAI o3 coverage and December LLM roundup
+3. **2024-12-16** - Veo 2 (Google) and WebDev Arena (OpenAI)
+4. **2024-12-13** - Google model-viewer component and OpenAI postmortem/FAQ
+5. **2024-12-04** - Google Genie 2 and Amazon Nova LLMs coverage
+6. **2024-11-21** - NotebookLM quotation and tiktoken/chess LLM articles
+7. **2024-11-19** - Gemini API ToS and Bing Chat manipulative AI notes
+8. **2024-10-23** - Google Gemini tooling and OpenAI revenue quotation
+9. **2024-10-03** - Gemini 1.5 Flash-8B (tagged with both)
+10. **2024-08-24** - SQL pipe syntax and OAuth/LLM musings
+11. **2024-08-08** - Gemini price drop and GPT-4o System Card
+12. **2024-07-16** - Quotation about OpenAI and Anthropic (tagged with both)
+13. **2024-07-09** - Google Hangouts code and OpenAI capabilities quotation
+14. **2024-05-24** - AI Overviews issues and ChatGPT hallucination reports
+15. **2024-05-17** - Gemini error understanding and OpenAI off-boarding quotation
+16. **2024-05-15** - PaliGemma model and OpenAI Projects/ChatGPT 4o coverage
+17. **2024-05-14** - Gemini context window/caching and voice assistant article
+18. **2024-04-10** - Gemini 1.5 Pro preview and LLM releases coverage
+
+### Content Type Distribution
+
+The qualifying content includes:
+- **Blog entries:** Full articles covering LLM developments, analysis, and commentary
+- **Blogmarks:** Curated links to external resources with commentary
+- **Quotations:** Notable quotes from articles, papers, or sources
+- **Notes:** Shorter-form content and observations
+
+### Patterns Observed
+
+1. **Dual Tagging:** Some items are tagged with both 'google' and 'openai' (e.g., comparative content, industry roundups)
+2. **Same-Day Coverage:** Many days have separate items covering Google and OpenAI news independently
+3. **LLM News Cycles:** Clustering around major announcements (May: GPT-4o launch, December: OpenAI o3)
+4. **Diverse Content:** Mix of technical coverage, business news, and critical commentary
+
+## Files
+
+- **`query_builder.py`** - Python script to query the Datasette API and analyze results
+- **`results.json`** - Complete JSON output with all 18 days and their associated content
+- **`notes.md`** - Working notes from the investigation process
+- **`README.md`** - This report
+
+## Usage
+
+To reproduce these results:
+
+```bash
+python3 query_builder.py
+```
+
+This will:
+1. Query the Datasette API for all 2024 content tagged with 'google' or 'openai'
+2. Group results by date
+3. Identify days with both tags present
+4. Output results to console and save to `results.json`
+
+## Technical Notes
+
+- **Date handling:** The database stores dates as TEXT, requiring the `date()` function for normalization
+- **Tag matching:** Case-sensitive matching on exact tag names 'google' and 'openai'
+- **Year filtering:** Uses `LIKE '2024%'` pattern matching for efficiency
+- **API format:** Results requested with `_shape=array` for cleaner JSON parsing
+
+## Conclusion
+
+The analysis successfully identified 18 days in 2024 where Simon Willison's blog contained content tagged with both Google and OpenAI. The content spans multiple formats (entries, blogmarks, quotations, notes) and covers a wide range of topics from technical announcements to industry commentary, reflecting the competitive and interconnected nature of the LLM landscape throughout 2024.

--- a/google-openai-days-2024/README.md
+++ b/google-openai-days-2024/README.md
@@ -42,6 +42,16 @@ WITH all_tagged_content AS (
 
 Post-processing in Python grouped results by date and identified days with both tags.
 
+## Interactive Queries
+
+Explore the data yourself with these Datasette queries:
+
+- **[All content tagged 'google' or 'openai' in 2024](https://datasette.simonwillison.net/simonwillisonblog?sql=WITH+all_tagged_content+AS+%28%0D%0A++SELECT%0D%0A++++date%28e.created%29+as+content_date%2C%0D%0A++++t.tag%2C%0D%0A++++%27entry%27+as+content_type%2C%0D%0A++++e.id+as+content_id%2C%0D%0A++++e.title+as+title%0D%0A++FROM+blog_entry+e%0D%0A++JOIN+blog_entry_tags+et+ON+e.id+%3D+et.entry_id%0D%0A++JOIN+blog_tag+t+ON+et.tag_id+%3D+t.id%0D%0A++WHERE+t.tag+IN+%28%27google%27%2C+%27openai%27%29%0D%0A++++AND+e.created+LIKE+%272024%25%27%0D%0A%0D%0A++UNION+ALL%0D%0A%0D%0A++SELECT%0D%0A++++date%28b.created%29+as+content_date%2C%0D%0A++++t.tag%2C%0D%0A++++%27blogmark%27+as+content_type%2C%0D%0A++++b.id+as+content_id%2C%0D%0A++++b.link_title+as+title%0D%0A++FROM+blog_blogmark+b%0D%0A++JOIN+blog_blogmark_tags+bt+ON+b.id+%3D+bt.blogmark_id%0D%0A++JOIN+blog_tag+t+ON+bt.tag_id+%3D+t.id%0D%0A++WHERE+t.tag+IN+%28%27google%27%2C+%27openai%27%29%0D%0A++++AND+b.created+LIKE+%272024%25%27%0D%0A%0D%0A++UNION+ALL%0D%0A%0D%0A++SELECT%0D%0A++++date%28q.created%29+as+content_date%2C%0D%0A++++t.tag%2C%0D%0A++++%27quotation%27+as+content_type%2C%0D%0A++++q.id+as+content_id%2C%0D%0A++++substr%28q.quotation%2C+1%2C+50%29+as+title%0D%0A++FROM+blog_quotation+q%0D%0A++JOIN+blog_quotation_tags+qt+ON+q.id+%3D+qt.quotation_id%0D%0A++JOIN+blog_tag+t+ON+qt.tag_id+%3D+t.id%0D%0A++WHERE+t.tag+IN+%28%27google%27%2C+%27openai%27%29%0D%0A++++AND+q.created+LIKE+%272024%25%27%0D%0A%0D%0A++UNION+ALL%0D%0A%0D%0A++SELECT%0D%0A++++date%28n.created%29+as+content_date%2C%0D%0A++++t.tag%2C%0D%0A++++%27note%27+as+content_type%2C%0D%0A++++n.id+as+content_id%2C%0D%0A++++n.title+as+title%0D%0A++FROM+blog_note+n%0D%0A++JOIN+blog_note_tags+nt+ON+n.id+%3D+nt.note_id%0D%0A++JOIN+blog_tag+t+ON+nt.tag_id+%3D+t.id%0D%0A++WHERE+t.tag+IN+%28%27google%27%2C+%27openai%27%29%0D%0A++++AND+n.created+LIKE+%272024%25%27%0D%0A%29%0D%0ASELECT%0D%0A++content_date%2C%0D%0A++content_type%2C%0D%0A++content_id%2C%0D%0A++title%2C%0D%0A++tag%0D%0AFROM+all_tagged_content%0D%0AORDER+BY+content_date+DESC%2C+content_type%2C+content_id)**
+
+- **[Just entries tagged 'google' or 'openai' in 2024](https://datasette.simonwillison.net/simonwillisonblog?sql=SELECT+date%28e.created%29+as+content_date%2C+t.tag%2C+e.title%0AFROM+blog_entry+e%0AJOIN+blog_entry_tags+et+ON+e.id+%3D+et.entry_id%0AJOIN+blog_tag+t+ON+et.tag_id+%3D+t.id%0AWHERE+t.tag+IN+%28%27google%27%2C+%27openai%27%29+AND+e.created+LIKE+%272024%25%27%0AORDER+BY+e.created+DESC)**
+
+- **[Database schema](https://datasette.simonwillison.net/simonwillisonblog?sql=select+sql+from+sqlite_master+where+name+like+%27blog_%25%27+order+by+name)**
+
 ## Results
 
 ### Statistics

--- a/google-openai-days-2024/notes.md
+++ b/google-openai-days-2024/notes.md
@@ -1,0 +1,55 @@
+# Investigation Notes: Google and OpenAI Tagged Content Days in 2024
+
+## Objective
+Find every day within 2024 when there was at least one item of content tagged "google" and at least one other item of content tagged "openai" (or both tags on same item).
+
+## Schema Discovery
+
+### Content Types
+- **blog_entry** - Main blog posts
+- **blog_blogmark** - Bookmarked links
+- **blog_quotation** - Quotations
+- **blog_note** - Short notes
+
+### Tag System
+- **blog_tag** - Tags table
+- **blog_entry_tags**, **blog_blogmark_tags**, **blog_quotation_tags**, **blog_note_tags** - Junction tables linking content to tags
+
+Each content type has:
+- A date field (need to identify exact field names)
+- A tags junction table linking to blog_tag
+
+## Key Findings
+- All content tables have a `created` field (TEXT type)
+- Tags 'google' and 'openai' both exist in the database
+- Need to UNION across all 4 content types to get complete picture
+
+## Approach
+1. Create a CTE that UNIONs all content types with their tags and dates
+2. Filter for 2024 content tagged with 'google' or 'openai'
+3. Group results by date to identify days with both tags present
+4. Built Python script (query_builder.py) to execute query and analyze results
+
+## Query Execution Results
+
+Successfully ran the query and found:
+- **178 total tagged content items** (entries, blogmarks, quotations, notes) with either 'google' or 'openai' tags in 2024
+- **18 days in 2024** had content tagged with BOTH 'google' and 'openai'
+
+### Observations
+1. Content is spread across all four types: entries, blogmarks, quotations, and notes
+2. Some days have a single item tagged with both tags (e.g., 2024-12-31)
+3. Other days have multiple items, each tagged with different tags (e.g., 2024-12-20 has 1 google item and 4 openai items)
+4. The query correctly handles both scenarios:
+   - Single item tagged with both google AND openai
+   - Multiple items on same day, some tagged google, others tagged openai
+
+### Date Range
+- Latest: 2024-12-31 (Things we learned about LLMs in 2024)
+- Earliest: 2024-04-10 (Gemini 1.5 Pro public preview and LLM releases)
+
+## Technical Details
+- Used SQLite date() function to normalize dates from TEXT format
+- UNION ALL across all 4 content types
+- Filtered by year using `created LIKE '2024%'`
+- Post-processed results in Python to group by date and identify days with both tags

--- a/google-openai-days-2024/query_builder.py
+++ b/google-openai-days-2024/query_builder.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Query builder to find days in 2024 with both google and openai tagged content
+"""
+
+import requests
+import json
+from datetime import datetime
+from collections import defaultdict
+from urllib.parse import quote
+
+BASE_URL = "https://datasette.simonwillison.net/simonwillisonblog.json"
+
+def fetch_query(sql):
+    """Execute a SQL query against the Datasette API"""
+    url = f"{BASE_URL}?sql={quote(sql)}&_shape=array"
+    print(f"Fetching: {url[:100]}...")
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.json()
+
+# Query to get all content with google or openai tags in 2024
+query = """
+WITH all_tagged_content AS (
+  -- Blog entries
+  SELECT
+    date(e.created) as content_date,
+    t.tag,
+    'entry' as content_type,
+    e.id as content_id,
+    e.title as title
+  FROM blog_entry e
+  JOIN blog_entry_tags et ON e.id = et.entry_id
+  JOIN blog_tag t ON et.tag_id = t.id
+  WHERE t.tag IN ('google', 'openai')
+    AND e.created LIKE '2024%'
+
+  UNION ALL
+
+  -- Blogmarks
+  SELECT
+    date(b.created) as content_date,
+    t.tag,
+    'blogmark' as content_type,
+    b.id as content_id,
+    b.link_title as title
+  FROM blog_blogmark b
+  JOIN blog_blogmark_tags bt ON b.id = bt.blogmark_id
+  JOIN blog_tag t ON bt.tag_id = t.id
+  WHERE t.tag IN ('google', 'openai')
+    AND b.created LIKE '2024%'
+
+  UNION ALL
+
+  -- Quotations
+  SELECT
+    date(q.created) as content_date,
+    t.tag,
+    'quotation' as content_type,
+    q.id as content_id,
+    substr(q.quotation, 1, 50) as title
+  FROM blog_quotation q
+  JOIN blog_quotation_tags qt ON q.id = qt.quotation_id
+  JOIN blog_tag t ON qt.tag_id = t.id
+  WHERE t.tag IN ('google', 'openai')
+    AND q.created LIKE '2024%'
+
+  UNION ALL
+
+  -- Notes
+  SELECT
+    date(n.created) as content_date,
+    t.tag,
+    'note' as content_type,
+    n.id as content_id,
+    n.title as title
+  FROM blog_note n
+  JOIN blog_note_tags nt ON n.id = nt.note_id
+  JOIN blog_tag t ON nt.tag_id = t.id
+  WHERE t.tag IN ('google', 'openai')
+    AND n.created LIKE '2024%'
+)
+SELECT
+  content_date,
+  content_type,
+  content_id,
+  title,
+  tag
+FROM all_tagged_content
+ORDER BY content_date DESC, content_type, content_id
+"""
+
+def main():
+    print("Fetching all content tagged with 'google' or 'openai' in 2024...")
+    results = fetch_query(query)
+
+    print(f"\nFound {len(results)} tagged content items")
+
+    # Group by date to find days with both tags
+    days_data = defaultdict(lambda: {'google': [], 'openai': []})
+
+    for item in results:
+        date = item['content_date']
+        tag = item['tag']
+        days_data[date][tag].append({
+            'type': item['content_type'],
+            'id': item['content_id'],
+            'title': item['title']
+        })
+
+    # Find days with both tags
+    days_with_both = []
+    for date in sorted(days_data.keys(), reverse=True):
+        has_google = len(days_data[date]['google']) > 0
+        has_openai = len(days_data[date]['openai']) > 0
+
+        if has_google and has_openai:
+            days_with_both.append({
+                'date': date,
+                'google_items': days_data[date]['google'],
+                'openai_items': days_data[date]['openai']
+            })
+
+    print(f"\nDays in 2024 with both 'google' and 'openai' tagged content: {len(days_with_both)}")
+    print("\n" + "="*80)
+
+    for day in days_with_both:
+        print(f"\n📅 {day['date']}")
+        print(f"   Google-tagged items: {len(day['google_items'])}")
+        for item in day['google_items']:
+            print(f"     - {item['type']}: {item['title']}")
+        print(f"   OpenAI-tagged items: {len(day['openai_items'])}")
+        for item in day['openai_items']:
+            print(f"     - {item['type']}: {item['title']}")
+
+    # Save results to JSON
+    with open('results.json', 'w') as f:
+        json.dump({
+            'total_days': len(days_with_both),
+            'days': days_with_both
+        }, f, indent=2)
+
+    print(f"\n✅ Results saved to results.json")
+
+    return days_with_both
+
+if __name__ == '__main__':
+    main()

--- a/google-openai-days-2024/results.json
+++ b/google-openai-days-2024/results.json
@@ -1,0 +1,361 @@
+{
+  "total_days": 18,
+  "days": [
+    {
+      "date": "2024-12-31",
+      "google_items": [
+        {
+          "type": "entry",
+          "id": 8685,
+          "title": "Things we learned about LLMs in 2024"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "entry",
+          "id": 8685,
+          "title": "Things we learned about LLMs in 2024"
+        }
+      ]
+    },
+    {
+      "date": "2024-12-20",
+      "google_items": [
+        {
+          "type": "entry",
+          "id": 8681,
+          "title": "December in LLMs has been a lot"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 8388,
+          "title": "OpenAI o3 breakthrough high score on ARC-AGI-PUB"
+        },
+        {
+          "type": "entry",
+          "id": 8681,
+          "title": "December in LLMs has been a lot"
+        },
+        {
+          "type": "entry",
+          "id": 8682,
+          "title": "Live blog: the 12th day of OpenAI - \"Early evals for OpenAI o3\""
+        },
+        {
+          "type": "quotation",
+          "id": 1558,
+          "title": "OpenAI's new o3 system - trained on the ARC-AGI-1 "
+        }
+      ]
+    },
+    {
+      "date": "2024-12-16",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8377,
+          "title": "Veo 2"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 8376,
+          "title": "WebDev Arena"
+        }
+      ]
+    },
+    {
+      "date": "2024-12-13",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8369,
+          "title": "<model-viewer> Web Component by Google"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 8368,
+          "title": "OpenAI's postmortem for API, ChatGPT & Sora Facing Issues"
+        },
+        {
+          "type": "blogmark",
+          "id": 8370,
+          "title": "OpenAI: Voice mode FAQ"
+        }
+      ]
+    },
+    {
+      "date": "2024-12-04",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8347,
+          "title": "Genie 2: A large-scale foundation world model"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "entry",
+          "id": 8645,
+          "title": "First impressions of the new Amazon Nova LLMs (via a new llm-bedrock plugin)"
+        }
+      ]
+    },
+    {
+      "date": "2024-11-21",
+      "google_items": [
+        {
+          "type": "quotation",
+          "id": 1532,
+          "title": "When we started working on what became NotebookLM "
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 8314,
+          "title": "A warning about tiktoken, BPE, and OpenAI models"
+        },
+        {
+          "type": "blogmark",
+          "id": 8316,
+          "title": "OK, I can partly explain the LLM chess weirdness now"
+        }
+      ]
+    },
+    {
+      "date": "2024-11-19",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8306,
+          "title": "Preview: Gemini API Additional Terms of Service"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "entry",
+          "id": 8611,
+          "title": "Notes from Bing Chat\u2014Our First Encounter With Manipulative AI"
+        }
+      ]
+    },
+    {
+      "date": "2024-10-23",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8247,
+          "title": "Running prompts against images and PDFs with Google Gemini"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "quotation",
+          "id": 1504,
+          "title": "OpenAI\u2019s monthly revenue hit $300 million in Augus"
+        }
+      ]
+    },
+    {
+      "date": "2024-10-03",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8155,
+          "title": "Gemini 1.5 Flash-8B is now production ready"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 8155,
+          "title": "Gemini 1.5 Flash-8B is now production ready"
+        }
+      ]
+    },
+    {
+      "date": "2024-08-24",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8081,
+          "title": "SQL Has Problems. We Can Fix Them: Pipe Syntax In SQL"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 8080,
+          "title": "Musing about OAuth and LLMs on Mastodon"
+        }
+      ]
+    },
+    {
+      "date": "2024-08-08",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 8041,
+          "title": "Gemini 1.5 Flash price drop"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 8041,
+          "title": "Gemini 1.5 Flash price drop"
+        },
+        {
+          "type": "blogmark",
+          "id": 8042,
+          "title": "GPT-4o System Card"
+        }
+      ]
+    },
+    {
+      "date": "2024-07-16",
+      "google_items": [
+        {
+          "type": "quotation",
+          "id": 1350,
+          "title": "OpenAI and Anthropic focused on building models an"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "quotation",
+          "id": 1350,
+          "title": "OpenAI and Anthropic focused on building models an"
+        }
+      ]
+    },
+    {
+      "date": "2024-07-09",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 7943,
+          "title": "hangout_services/thunk.js"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "quotation",
+          "id": 1335,
+          "title": "Inside the labs we have these capable models, and "
+        }
+      ]
+    },
+    {
+      "date": "2024-05-24",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 7825,
+          "title": "Some goofy results from \u2018AI Overviews\u2019 in Google Search"
+        },
+        {
+          "type": "quotation",
+          "id": 1251,
+          "title": "I just left Google last month. The \"AI Projects\" I"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 7826,
+          "title": "Nilay Patel reports a hallucinated ChatGPT summary of his own article"
+        }
+      ]
+    },
+    {
+      "date": "2024-05-17",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 7813,
+          "title": "Understand errors and warnings better with Gemini"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "quotation",
+          "id": 1243,
+          "title": "I have seen the extremely restrictive off-boarding"
+        }
+      ]
+    },
+    {
+      "date": "2024-05-15",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 7808,
+          "title": "PaliGemma model README"
+        },
+        {
+          "type": "quotation",
+          "id": 1241,
+          "title": "But where the company once limited itself to gathe"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 7807,
+          "title": "OpenAI: Managing your work in the API platform with Projects"
+        },
+        {
+          "type": "entry",
+          "id": 8342,
+          "title": "ChatGPT in \"4o\" mode is not running the new features yet"
+        }
+      ]
+    },
+    {
+      "date": "2024-05-14",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 7803,
+          "title": "How developers are using Gemini 1.5 Pro\u2019s 1 million token context window"
+        },
+        {
+          "type": "blogmark",
+          "id": 7805,
+          "title": "Context caching for Google Gemini"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "blogmark",
+          "id": 7802,
+          "title": "Why your voice assistant might be sexist"
+        }
+      ]
+    },
+    {
+      "date": "2024-04-10",
+      "google_items": [
+        {
+          "type": "blogmark",
+          "id": 7670,
+          "title": "Gemini 1.5 Pro public preview"
+        }
+      ],
+      "openai_items": [
+        {
+          "type": "entry",
+          "id": 8336,
+          "title": "Three major LLM releases in 24 hours (plus weeknotes)"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Analyzed Simon Willison's blog database to find days in 2024 when content
was tagged with both 'google' and 'openai' tags.

Key findings:
- 18 days identified with content tagged with both tags
- 178 total tagged items across entries, blogmarks, quotations, and notes
- Date range: April 10, 2024 to December 31, 2024

Includes:
- Python script to query Datasette API and analyze results
- Complete JSON output with all qualifying days and content
- Investigation notes and comprehensive README report