### PR TITLE
Investigate PostgreSQL safety model for untrusted queries

### DIFF
--- a/postgresql-time-limits-readonly/README.md
+++ b/postgresql-time-limits-readonly/README.md
@@ -1,0 +1,145 @@
+# Running untrusted queries: Datasette/SQLite vs psycopg/PostgreSQL
+
+Datasette lets anyone type arbitrary SQL into a public box and run it against a
+database without fear of data corruption or resource exhaustion. This
+investigation documents exactly how it achieves that with SQLite, then
+determines whether **psycopg + PostgreSQL** can be locked down the same way.
+
+Short answer: **yes — and in some respects PostgreSQL does it better** (its
+time limit also catches sleeping/blocked queries, and it adds disk/memory
+knobs SQLite lacks). The one important difference is that PostgreSQL's
+read-only flag is a *soft* setting; the hard barrier is the GRANT
+privilege system.
+
+## How Datasette protects SQLite
+
+Read from a fresh clone of `simonw/datasette`. Two mechanisms do the work:
+
+### 1. Read-only at the connection level
+`Database.connect()` (`datasette/database.py`) opens query connections with a
+SQLite URI that makes writes impossible:
+
+- mutable files: `file:{path}?mode=ro`
+- immutable files: `file:{path}?immutable=1`
+- shared in-memory DBs (where `mode=ro` is unavailable): `PRAGMA query_only=1`
+
+Writes are physically segregated onto a **separate write connection** running on
+a single dedicated write thread (`isolation_level="IMMEDIATE"`). Read
+connections simply *cannot* write — it's enforced by SQLite at file-open time,
+not by inspecting the SQL.
+
+### 2. A per-query time limit inside the SQLite VM
+`sqlite_timelimit()` (`datasette/utils/__init__.py`) wraps every read query:
+
+```python
+def handler():
+    if time.perf_counter() >= deadline:
+        return 1            # non-zero aborts the query
+conn.set_progress_handler(handler, n)   # checked every n=1000 VM ops
+```
+
+A non-zero return from the progress handler makes SQLite abort with
+`OperationalError: interrupted`, which Datasette turns into `QueryInterrupted`.
+Default limit is `sql_time_limit_ms = 1000`. This stops runaway CPU work such
+as an infinite recursive CTE. (Limitation: the progress handler fires on VM
+instructions, so a query that *sleeps* wouldn't be caught — not an issue for
+SQLite, which has no sleep.)
+
+### 3. Defence in depth
+- `validate_sql_select()` — regex allowlist; SQL must start with
+  `select`/`with`/`explain`; PRAGMAs blocked except a safe allowlist.
+- `max_returned_rows` (default 1000) via `fetchmany(max+1)` — bounds memory.
+- Queries run on a thread pool so a slow one never blocks the event loop.
+
+The crucial design point: **read-only and the time limit are enforced by the
+engine/connection, not by parsing the SQL.** SQL validation is only an extra
+layer.
+
+## The same protections in PostgreSQL + psycopg
+
+Setup (see `notes.md`): PostgreSQL 16, a least-privilege `untrusted` role, and
+psycopg 3.3.4. `pg_experiments.py` exercises each protection.
+
+| Datasette / SQLite | PostgreSQL / psycopg | Result |
+|---|---|---|
+| `mode=ro` / `immutable=1` (hard) | **least-privilege GRANTs** (SELECT only, REVOKE write/TEMP/CREATE) | hard barrier ✓ |
+| `PRAGMA query_only=1` | `default_transaction_read_only=on` / `conn.read_only=True` | soft guard ✓ |
+| progress-handler time limit | `statement_timeout` (per-role / per-session / per-connection) | ✓, also catches sleeps |
+| `max_returned_rows` + `fetchmany` | server-side (named) cursor + `fetchmany` | ✓ |
+| *(no equivalent)* | `temp_file_limit`, `work_mem`, idle-txn timeout, per-role conn limits | bonus ✓ |
+
+### What the experiments showed
+1. **Time limit works and is stronger.** With `statement_timeout=1000ms`, an
+   infinite recursive CTE *and* `pg_sleep(10)` were both cancelled at ~1s with
+   `QueryCanceled`. SQLite's progress handler would not have interrupted a
+   sleep. Settable per-role (`ALTER ROLE`), per-session (`SET`), or per
+   connection (`options='-c statement_timeout=...'`); the per-session form is
+   the direct analogue of Datasette's per-query `custom_time_limit`.
+
+2. **Read-only works — with a caveat.** `default_transaction_read_only=on` and
+   psycopg's `conn.read_only=True` both reject INSERT/UPDATE/DDL with
+   `ReadOnlySqlTransaction` (the latter even for a superuser connection).
+   **But** a role that owns its session can `SET default_transaction_read_only
+   = off` for a fresh transaction — so the flag is a convenience guard, not a
+   security boundary. The *hard* barrier is the **privilege system**: with only
+   `SELECT` granted, the escaped INSERT was stopped by `InsufficientPrivilege`.
+   This differs from SQLite, where `mode=ro` is enforced at file-open and
+   cannot be escaped from inside the connection.
+
+   **Robust recipe:** least-privilege role (SELECT only, no write grants,
+   `REVOKE TEMP/CREATE`) **plus** read-only transaction **plus**
+   `statement_timeout`.
+
+3. **Memory/disk limits.** A server-side cursor with `fetchmany(N)` bounds
+   client memory exactly like Datasette's `fetchmany(max_returned_rows+1)`.
+   `temp_file_limit=10MB` aborted a huge disk-spilling sort with
+   `ConfigurationLimitExceeded` — a resource knob SQLite has no equivalent for.
+
+## Bonus: a Datasette-style database backed by PostgreSQL
+
+`pg_datasette_poc.py` reimplements Datasette's `Database.execute()` contract —
+`Results(rows, truncated, description)`, `QueryInterrupted`, async `execute()`,
+`custom_time_limit` — backed by psycopg. Every connection is pinned to
+`conn.read_only=True` and a `statement_timeout`. Demo output (`poc_output.txt`):
+
+```
+1) ordinary SELECT                       -> rows returned
+2) row cap / truncation (10000 -> 1000)  -> truncated: True
+3) runaway recursive CTE                 -> QueryInterrupted
+4) write attempt                         -> blocked (read-only)
+5) custom 200ms limit on pg_sleep(5)     -> QueryInterrupted
+```
+
+A *full* fork of Datasette onto PostgreSQL is impractical in this scope: the
+view and introspection layers are wired to SQLite specifics (`sqlite3.Row`,
+`PRAGMA table_info`/`database_list`, `ATTACH`, file hash/size, the write-thread
+model). The `PostgresDatabase` class here is the core storage adapter such a
+fork would be built around — it preserves the exact safety contract, which is
+the heart of the question. A real port would additionally swap introspection to
+`information_schema`/`pg_catalog` and drop the file-immutability paths.
+
+## Conclusion
+
+PostgreSQL + psycopg can run untrusted queries as safely as Datasette runs them
+on SQLite. The time limit (`statement_timeout`) is a clean, superior analogue.
+The one mental-model shift: in SQLite "read-only" is a property of how the file
+is opened; in PostgreSQL the durable read-only guarantee comes from **granting
+only SELECT** to the query role, with the read-only transaction flag as a
+secondary belt-and-braces layer.
+
+## Files
+- `notes.md` — running investigation log
+- `pg_experiments.py` — protection experiments (time limit, read-only, limits)
+- `pg_datasette_poc.py` — Datasette-style `Database` class on PostgreSQL
+- `experiments_output.txt`, `poc_output.txt` — captured runs
+
+## Reproducing
+```bash
+# PostgreSQL 16 as an unprivileged user (initdb refuses root):
+initdb -D /tmp/pgdata -U postgres --auth=trust
+pg_ctl -D /tmp/pgdata -o '-k /tmp/pgrun -p 5432' start
+# create testdb + least-privilege 'untrusted' role (see notes.md), then:
+python -m venv venv && venv/bin/pip install 'psycopg[binary]'
+venv/bin/python pg_experiments.py
+venv/bin/python pg_datasette_poc.py
+```

--- a/postgresql-time-limits-readonly/experiments_output.txt
+++ b/postgresql-time-limits-readonly/experiments_output.txt
@@ -1,0 +1,31 @@
+
+======================================================================
+1. statement_timeout aborts a runaway query
+======================================================================
+[ERR]  infinite recursive CTE (expect timeout ~1s): QueryCanceled: canceling statement due to statement timeout  (1016ms)
+[ERR]  pg_sleep(10) (expect timeout ~1s): QueryCanceled: canceling statement due to statement timeout  (1004ms)
+[OK ]  statement_timeout setting on untrusted role: 1s  (4ms)
+[OK ]  per-connection SET statement_timeout=300ms on superuser: cancelled after 301ms  (304ms)
+
+======================================================================
+2. Read-only enforcement
+======================================================================
+[ERR]  INSERT as untrusted role (expect read-only error): ReadOnlySqlTransaction: cannot execute INSERT in a read-only transaction  (5ms)
+[ERR]  UPDATE as untrusted role (expect read-only error): ReadOnlySqlTransaction: cannot execute UPDATE in a read-only transaction  (4ms)
+[ERR]  CREATE TABLE as untrusted role (expect error): ReadOnlySqlTransaction: cannot execute CREATE TABLE in a read-only transaction  (3ms)
+[OK ]  SELECT as untrusted role (expect success): count=1000  (4ms)
+[OK ]  conn.read_only=True blocks write even for superuser: blocked by conn.read_only=True even as superuser  (3ms)
+[OK ]  untrusted tries SET read_only=off then INSERT: still blocked: ReadOnlySqlTransaction  (3ms)
+
+======================================================================
+3. Resource limits: rows, memory, temp files
+======================================================================
+[OK ]  server-side cursor + fetchmany caps rows streamed: fetched 1001 rows then stopped (no full materialise)  (1005ms)
+[OK ]  temp_file_limit=10MB caps disk spill of large sort: blocked by temp_file_limit: temporary file size exceeds temp_file_limit (10240kB)  (168ms)
+
+======================================================================
+4. Read-only is soft; GRANTs are the hard barrier
+======================================================================
+[OK ]  untrusted flips read_only=off in fresh txn: read_only flipped off, but blocked by GRANTs (the real barrier)  (7ms)
+[OK ]  server-side cursor + fetchmany bounds client memory: pulled 1001 of 5M wide rows; client memory bounded  (501ms)
+psycopg version: 3.3.4

--- a/postgresql-time-limits-readonly/notes.md
+++ b/postgresql-time-limits-readonly/notes.md
@@ -1,0 +1,114 @@
+# Notes
+
+## Step 1: Datasette's SQLite safety model (cloned to /tmp/datasette)
+
+Key findings from reading the code:
+
+### 1. Read-only connections (datasette/database.py `Database.connect()`, ~line 137)
+- File databases opened with SQLite URI: `file:{path}?mode=ro` (mutable files)
+  or `file:{path}?immutable=1` (immutable files). `?nolock=1` optionally added.
+- Shared in-memory databases (`file:name?mode=memory&cache=shared`) can't use
+  mode=ro, so Datasette runs `PRAGMA query_only=1` on read connections instead.
+- Writes go through a *separate* dedicated write connection on a single
+  write thread (`execute_write_fn` / `_write_queue`), opened without mode=ro
+  and with `isolation_level="IMMEDIATE"`.
+
+### 2. Time limits (datasette/utils/__init__.py `sqlite_timelimit`, line 245)
+- Context manager wraps every read query (database.py `execute()`, line 532).
+- Uses `conn.set_progress_handler(handler, n)` with n=1000 VM instructions
+  (n=1 if limit <= 20ms, for the test suite). Comment: ~0.08ms per 1000 ops.
+- Handler compares time.perf_counter() against a deadline; returning 1 from
+  the progress handler makes SQLite abort the query with
+  `sqlite3.OperationalError: interrupted`, which Datasette converts to
+  QueryInterrupted (database.py line 546-548).
+- Default `sql_time_limit_ms` setting = 1000ms; can be lowered per-query
+  via `custom_time_limit` (?_timelimit= param) but never raised above setting.
+
+### 3. Defense in depth
+- `validate_sql_select` (utils/__init__.py line 321): regex allowlist - SQL must
+  start with select/with/explain select/explain query plan; PRAGMA blocked
+  except an allowlist of pragma_*() table-valued functions.
+- `max_returned_rows` (default 1000): fetchmany(max+1) truncation so a huge
+  result set can't exhaust memory.
+- Queries run on a thread pool (num_sql_threads=3 default), one connection per
+  thread, so a slow query can't block the event loop.
+
+So: **readonly = enforced by the connection itself (mode=ro/immutable/query_only),
+not by SQL parsing; time limit = enforced inside the SQLite VM via progress
+handler, so it catches runaway CPU loops like recursive CTEs.**
+
+
+## Step 2: PostgreSQL + psycopg experiments (pg_experiments.py)
+
+Setup: PostgreSQL 16 in /tmp/pgdata, unix socket /tmp/pgrun, run as the
+`postgres` OS user (initdb refuses to run as root). psycopg 3.3.4 in
+/tmp/pgvenv. Created an `untrusted` LOGIN role with:
+    ALTER ROLE untrusted SET statement_timeout = '1000ms';
+    ALTER ROLE untrusted SET default_transaction_read_only = on;
+    REVOKE ALL/TEMP ON DATABASE testdb FROM PUBLIC;
+    GRANT CONNECT; GRANT USAGE ON SCHEMA; GRANT SELECT ON ALL TABLES.
+
+### Results
+1. TIME LIMIT (statement_timeout) — WORKS, and is *better* than SQLite's:
+   - Infinite recursive CTE -> QueryCanceled after ~1015ms.
+   - pg_sleep(10) -> QueryCanceled after ~1005ms. (SQLite's progress handler
+     would NOT interrupt a sleep, only VM instructions — PostgreSQL's timer
+     catches sleeping/blocked queries too.)
+   - Settable three ways: per-role (ALTER ROLE), per-session (SET), or per
+     connection via options='-c statement_timeout=1000'. Per-session SET is
+     the direct analogue of Datasette's per-query custom_time_limit.
+
+2. READ-ONLY — WORKS, but with an important distinction:
+   - default_transaction_read_only=on blocks INSERT/UPDATE/CREATE with
+     ReadOnlySqlTransaction.
+   - psycopg conn.read_only=True forces it client-side and blocks writes even
+     for a superuser connection (ReadOnlySqlTransaction).
+   - CAVEAT (important): default_transaction_read_only is a *soft* guard. A
+     role that owns its session can `SET default_transaction_read_only=off`
+     for a fresh (autocommit) transaction. It only held in my first test
+     because the SET + INSERT shared one already-read-only transaction.
+   - The REAL hard barrier is the GRANT privilege model: with only SELECT
+     granted, the escaped INSERT was blocked by InsufficientPrivilege. So the
+     robust recipe = least-privilege role (SELECT only, no write grants,
+     REVOKE TEMP/CREATE) PLUS read-only transaction PLUS statement_timeout.
+     This is unlike SQLite where mode=ro is enforced at the file-open level
+     and cannot be escaped from within the connection at all.
+
+3. RESOURCE LIMITS:
+   - Server-side (named) cursor + fetchmany(N) bounds client memory the same
+     way Datasette's fetchmany(max_returned_rows+1) does. Named cursors
+     require a transaction block (fail under autocommit).
+   - temp_file_limit (e.g. 10MB) aborts a huge disk-spilling sort with
+     ConfigurationLimitExceeded — a knob SQLite lacks. work_mem caps in-memory
+     sort/hash. These guard against resource exhaustion that a time limit
+     alone might not catch quickly.
+
+### Summary mapping
+   SQLite (Datasette)              ->  PostgreSQL (psycopg)
+   ----------------------------------------------------------
+   mode=ro / immutable=1           ->  least-privilege GRANTs (hard) +
+   PRAGMA query_only=1             ->    default_transaction_read_only /
+                                         conn.read_only (soft)
+   progress handler time limit     ->  statement_timeout (also catches sleeps)
+   max_returned_rows + fetchmany   ->  server-side cursor + fetchmany
+   (no equivalent)                 ->  temp_file_limit, work_mem, idle txn
+                                         timeout, per-role connection limits
+
+## Step 3: Datasette-style PoC (pg_datasette_poc.py)
+
+Reimplemented Datasette's Database.execute() contract — Results(rows,
+truncated, description), QueryInterrupted, async execute() — backed by psycopg.
+Each connection: conn.read_only=True + options='-c statement_timeout=...'.
+Per-query custom_time_limit uses SET LOCAL statement_timeout.
+
+Demo output (poc_output.txt): all 5 checks pass — plain SELECT, row-cap
+truncation at 1000, recursive-CTE timeout, write rejected, tight 200ms limit.
+
+### Bonus: full Datasette-on-PostgreSQL fork
+A complete fork is impractical in scope: Datasette's view/introspection layer
+is wired to sqlite3 specifics (sqlite3.Row, PRAGMA table_info/database_list,
+ATTACH, the dedicated write-thread model, hash/size of .db files). The
+PostgresDatabase class here is the core storage adapter such a fork would be
+built around — it preserves the exact safety contract, which was the crux of
+the question. A real port would also swap the introspection queries for
+information_schema/pg_catalog and drop the file-immutability code paths.

--- a/postgresql-time-limits-readonly/pg_datasette_poc.py
+++ b/postgresql-time-limits-readonly/pg_datasette_poc.py
@@ -1,0 +1,150 @@
+"""
+Proof-of-concept: a Datasette-style Database class backed by PostgreSQL.
+
+Datasette's datasette/database.py Database.execute() runs untrusted SELECTs
+against SQLite with three guarantees:
+  * the connection is read-only (mode=ro / PRAGMA query_only=1)
+  * a per-query time limit (progress handler) aborts runaway queries
+  * results are truncated to max_returned_rows so memory can't be exhausted
+
+This module reproduces that exact contract against PostgreSQL via psycopg,
+so a Datasette-like app could swap the storage engine and keep the same
+safety properties. It mirrors the public surface Datasette relies on:
+Results(rows, truncated, description), QueryInterrupted, and an async execute().
+"""
+import asyncio
+import psycopg
+from psycopg import sql as pgsql
+
+
+class QueryInterrupted(Exception):
+    "Raised when a query exceeds its time limit (mirrors datasette.database)."
+
+
+class Results:
+    def __init__(self, rows, truncated, description):
+        self.rows = rows
+        self.truncated = truncated
+        self.description = description
+
+    def __iter__(self):
+        return iter(self.rows)
+
+    def __len__(self):
+        return len(self.rows)
+
+
+class PostgresDatabase:
+    """Mirror of datasette.database.Database, backed by PostgreSQL.
+
+    The untrusted role is expected to already be least-privileged (SELECT
+    only, no write GRANTs, REVOKE TEMP/CREATE) - that is the hard read-only
+    barrier. We additionally pin every connection to a read-only transaction
+    and a statement_timeout as defence in depth.
+    """
+
+    def __init__(self, conninfo, sql_time_limit_ms=1000, max_returned_rows=1000):
+        self.conninfo = conninfo
+        self.sql_time_limit_ms = sql_time_limit_ms
+        self.max_returned_rows = max_returned_rows
+
+    def _connect(self):
+        # read_only=True forces a read-only transaction (analogue of mode=ro);
+        # options sets statement_timeout for the whole session (analogue of the
+        # SQLite progress-handler time limit).
+        conn = psycopg.connect(
+            self.conninfo,
+            autocommit=False,
+            options=f"-c statement_timeout={self.sql_time_limit_ms}",
+        )
+        conn.read_only = True
+        return conn
+
+    async def execute(self, sql, params=None, custom_time_limit=None, truncate=True):
+        """Run a read-only query with a time limit and row cap, off the event loop."""
+        return await asyncio.to_thread(
+            self._execute_sync, sql, params, custom_time_limit, truncate
+        )
+
+    def _execute_sync(self, sql, params, custom_time_limit, truncate):
+        time_limit_ms = self.sql_time_limit_ms
+        if custom_time_limit and custom_time_limit < time_limit_ms:
+            time_limit_ms = custom_time_limit
+        conn = self._connect()
+        try:
+            with conn.cursor() as cur:
+                if custom_time_limit:
+                    cur.execute(
+                        pgsql.SQL("SET LOCAL statement_timeout = {}").format(
+                            pgsql.Literal(time_limit_ms)
+                        )
+                    )
+                try:
+                    cur.execute(sql, params)
+                except psycopg.errors.QueryCanceled as e:
+                    raise QueryInterrupted(str(e)) from e
+                except (
+                    psycopg.errors.InsufficientPrivilege,
+                    psycopg.errors.ReadOnlySqlTransaction,
+                ) as e:
+                    # write attempt or unauthorised table - report, don't crash
+                    raise QueryInterrupted(f"not permitted: {e}") from e
+
+                max_rows = self.max_returned_rows
+                if truncate:
+                    rows = cur.fetchmany(max_rows + 1)
+                    truncated = len(rows) > max_rows
+                    rows = rows[:max_rows]
+                else:
+                    rows = cur.fetchall()
+                    truncated = False
+                description = cur.description
+            conn.rollback()
+            return Results(rows, truncated, description)
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------
+async def _demo():
+    db = PostgresDatabase(
+        "host=/tmp/pgrun user=untrusted dbname=testdb",
+        sql_time_limit_ms=1000,
+        max_returned_rows=1000,
+    )
+
+    print("1) ordinary SELECT")
+    r = await db.execute("SELECT id, name FROM items ORDER BY id LIMIT 3")
+    print("   rows:", r.rows, "truncated:", r.truncated)
+
+    print("2) row cap / truncation (10000 rows, cap 1000)")
+    r = await db.execute("SELECT * FROM generate_series(1, 10000)")
+    print("   returned:", len(r.rows), "truncated:", r.truncated)
+
+    print("3) time limit on runaway recursive CTE")
+    try:
+        await db.execute(
+            "WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM t) "
+            "SELECT count(*) FROM t"
+        )
+        print("   NO TIMEOUT - BAD")
+    except QueryInterrupted as e:
+        print("   QueryInterrupted:", str(e)[:50])
+
+    print("4) write attempt is rejected (read-only + least privilege)")
+    try:
+        await db.execute("INSERT INTO items(name) VALUES ('x')")
+        print("   WRITE SUCCEEDED - BAD")
+    except QueryInterrupted as e:
+        print("   blocked:", str(e)[:60])
+
+    print("5) custom (tighter) per-query time limit, 200ms")
+    try:
+        await db.execute("SELECT pg_sleep(5)", custom_time_limit=200)
+        print("   NO TIMEOUT - BAD")
+    except QueryInterrupted as e:
+        print("   QueryInterrupted (tight limit):", str(e)[:40])
+
+
+if __name__ == "__main__":
+    asyncio.run(_demo())

--- a/postgresql-time-limits-readonly/pg_experiments.py
+++ b/postgresql-time-limits-readonly/pg_experiments.py
@@ -1,0 +1,232 @@
+"""
+Experiments: can psycopg + PostgreSQL enforce the same protections Datasette
+relies on for SQLite when running untrusted queries?
+
+  1. statement_timeout  -> analogue of Datasette's progress-handler time limit
+  2. read-only enforcement -> analogue of mode=ro / PRAGMA query_only=1
+  3. row / memory limits -> analogue of max_returned_rows
+  4. blocking allocation / temp file abuse -> temp_file_limit, work_mem
+
+Run against the local server started on the unix socket in /tmp/pgrun.
+"""
+import time
+import psycopg
+
+HOST = "/tmp/pgrun"
+SUPERUSER = dict(host=HOST, user="postgres", dbname="testdb")
+UNTRUSTED = dict(host=HOST, user="untrusted", dbname="testdb")
+
+
+def section(title):
+    print("\n" + "=" * 70)
+    print(title)
+    print("=" * 70)
+
+
+def run(label, fn):
+    t0 = time.perf_counter()
+    try:
+        result = fn()
+        dt = (time.perf_counter() - t0) * 1000
+        print(f"[OK ]  {label}: {result}  ({dt:.0f}ms)")
+    except Exception as e:
+        dt = (time.perf_counter() - t0) * 1000
+        print(f"[ERR]  {label}: {type(e).__name__}: {e}  ({dt:.0f}ms)")
+
+
+# ---------------------------------------------------------------------------
+section("1. statement_timeout aborts a runaway query")
+# The untrusted role has statement_timeout=1000ms set via ALTER ROLE.
+
+def runaway_recursive_cte():
+    # PostgreSQL analogue of an infinite recursive CTE / CPU spin.
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("""
+                WITH RECURSIVE t(n) AS (
+                    SELECT 1
+                    UNION ALL
+                    SELECT n + 1 FROM t
+                )
+                SELECT count(*) FROM t
+            """)
+            return cur.fetchone()
+
+run("infinite recursive CTE (expect timeout ~1s)", runaway_recursive_cte)
+
+
+def pg_sleep_long():
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_sleep(10)")
+            return cur.fetchone()
+
+run("pg_sleep(10) (expect timeout ~1s)", pg_sleep_long)
+
+
+def confirm_role_timeout():
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SHOW statement_timeout")
+            return cur.fetchone()[0]
+
+run("statement_timeout setting on untrusted role", confirm_role_timeout)
+
+
+# A per-connection / per-query override is also possible without relying on
+# the role default - this is the closest analogue to Datasette's per-query
+# custom_time_limit.
+def per_query_timeout():
+    with psycopg.connect(**SUPERUSER) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = '300ms'")
+            t0 = time.perf_counter()
+            try:
+                cur.execute("SELECT pg_sleep(5)")
+            except psycopg.errors.QueryCanceled:
+                return f"cancelled after {(time.perf_counter()-t0)*1000:.0f}ms"
+
+run("per-connection SET statement_timeout=300ms on superuser", per_query_timeout)
+
+
+# ---------------------------------------------------------------------------
+section("2. Read-only enforcement")
+
+def write_blocked_by_readonly_role():
+    # untrusted role has default_transaction_read_only = on
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO items(name) VALUES ('hacked')")
+            return "INSERT SUCCEEDED - BAD"
+
+run("INSERT as untrusted role (expect read-only error)", write_blocked_by_readonly_role)
+
+
+def update_blocked():
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("UPDATE items SET name='x' WHERE id=1")
+            return "UPDATE SUCCEEDED - BAD"
+
+run("UPDATE as untrusted role (expect read-only error)", update_blocked)
+
+
+def ddl_blocked():
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("CREATE TABLE evil(x int)")
+            return "CREATE SUCCEEDED - BAD"
+
+run("CREATE TABLE as untrusted role (expect error)", ddl_blocked)
+
+
+def select_allowed():
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM items")
+            return f"count={cur.fetchone()[0]}"
+
+run("SELECT as untrusted role (expect success)", select_allowed)
+
+
+def readonly_session_attr():
+    # psycopg can also force the *session* to read-only regardless of role.
+    with psycopg.connect(**SUPERUSER) as conn:
+        conn.read_only = True
+        with conn.cursor() as cur:
+            try:
+                cur.execute("INSERT INTO items(name) VALUES ('via-superuser')")
+                return "INSERT SUCCEEDED - BAD (read_only attr ignored)"
+            except psycopg.errors.ReadOnlySqlTransaction:
+                return "blocked by conn.read_only=True even as superuser"
+
+run("conn.read_only=True blocks write even for superuser", readonly_session_attr)
+
+
+# Can the untrusted role escape read-only by issuing its own SET?
+def escape_readonly_attempt():
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = off")
+            try:
+                cur.execute("INSERT INTO items(name) VALUES ('escaped')")
+                return "ESCAPED read-only - BAD"
+            except Exception as e:
+                return f"still blocked: {type(e).__name__}"
+
+run("untrusted tries SET read_only=off then INSERT", escape_readonly_attempt)
+
+
+# ---------------------------------------------------------------------------
+section("3. Resource limits: rows, memory, temp files")
+
+def row_limit_via_fetchmany():
+    # Datasette uses fetchmany(max+1). psycopg server-side cursor streams.
+    with psycopg.connect(**UNTRUSTED) as conn:
+        with conn.cursor(name="srv") as cur:  # named => server-side cursor
+            cur.execute("SELECT * FROM generate_series(1, 10000000)")
+            rows = cur.fetchmany(1001)
+            return f"fetched {len(rows)} rows then stopped (no full materialise)"
+
+run("server-side cursor + fetchmany caps rows streamed", row_limit_via_fetchmany)
+
+
+def temp_file_limit():
+    # A big sort can spill to disk; temp_file_limit caps that.
+    with psycopg.connect(**SUPERUSER) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET temp_file_limit = '10MB'")
+            cur.execute("SET work_mem = '64kB'")
+            cur.execute("SET statement_timeout = 0")
+            try:
+                cur.execute(
+                    "SELECT count(*) FROM (SELECT * FROM generate_series(1, 50000000) "
+                    "ORDER BY random()) s"
+                )
+                return "completed without hitting temp_file_limit"
+            except psycopg.errors.ConfigurationLimitExceeded as e:
+                return f"blocked by temp_file_limit: {str(e)[:60]}"
+            except Exception as e:
+                return f"{type(e).__name__}: {str(e)[:60]}"
+
+run("temp_file_limit=10MB caps disk spill of large sort", temp_file_limit)
+
+
+# ---------------------------------------------------------------------------
+section("4. Read-only is soft; GRANTs are the hard barrier")
+
+
+def escape_via_fresh_txn():
+    # In autocommit each statement is its own txn, so SET read_only=off DOES
+    # take effect for the subsequent INSERT. The write is then stopped only by
+    # the privilege system (untrusted has SELECT but not INSERT on items).
+    with psycopg.connect(**UNTRUSTED, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = off")
+            try:
+                cur.execute("INSERT INTO items(name) VALUES ('escaped')")
+                return "INSERT SUCCEEDED - role had write privilege"
+            except psycopg.errors.InsufficientPrivilege:
+                return "read_only flipped off, but blocked by GRANTs (the real barrier)"
+
+run("untrusted flips read_only=off in fresh txn", escape_via_fresh_txn)
+
+
+def server_side_cursor_caps_memory():
+    with psycopg.connect(**SUPERUSER) as conn:  # autocommit off -> txn block
+        with conn.cursor() as c0:
+            c0.execute("SET statement_timeout = 0")
+        with conn.cursor(name="srv") as cur:
+            cur.itersize = 1000
+            cur.execute(
+                "SELECT g, repeat('x',100) FROM generate_series(1,5000000) g"
+            )
+            rows = cur.fetchmany(1001)
+            conn.rollback()
+            return f"pulled {len(rows)} of 5M wide rows; client memory bounded"
+
+run("server-side cursor + fetchmany bounds client memory", server_side_cursor_caps_memory)
+
+
+if __name__ == "__main__":
+    print("psycopg version:", psycopg.__version__)

--- a/postgresql-time-limits-readonly/poc_output.txt
+++ b/postgresql-time-limits-readonly/poc_output.txt
@@ -1,0 +1,10 @@
+1) ordinary SELECT
+   rows: [(1, 'item 1'), (2, 'item 2'), (3, 'item 3')] truncated: False
+2) row cap / truncation (10000 rows, cap 1000)
+   returned: 1000 truncated: True
+3) time limit on runaway recursive CTE
+   QueryInterrupted: canceling statement due to statement timeout
+4) write attempt is rejected (read-only + least privilege)
+   blocked: not permitted: cannot execute INSERT in a read-only transact
+5) custom (tighter) per-query time limit, 200ms
+   QueryInterrupted (tight limit): canceling statement due to statement tim


### PR DESCRIPTION
> Clone simonw/datasette from GitHub to /tmp
> 
> Explore how it uses SQLite - pay close attention to the way it relies on both readonly mode and setting a time limit such that it can run untrusted SQLite queries without fear of data corruption or resource exhaustion
> 
> Now set up a PostgreSQL server and install psycopg and perform experiments to determine if and how psycopg + PostgreSQL can be limited in the same ways - time limits and strict readonly mode
> 
> Bonus if you can get a branch of Datasette working with PostgreSQL instead

Effectively the same prompt as #113 but with PostgreSQL instead of DuckDB - and, just like in that one, Fable downgraded itself to Opus right as it was getting started for no apparent reason.

## Summary

This investigation documents how PostgreSQL + psycopg can enforce the same safety guarantees that Datasette relies on for SQLite when running untrusted queries. It includes experiments validating three core protections (time limits, read-only enforcement, resource limits) and a proof-of-concept `Database` class that mirrors Datasette's safety contract.

## Key Changes

- **pg_experiments.py**: Comprehensive test suite validating PostgreSQL's ability to enforce:
  - `statement_timeout` as an analogue to SQLite's progress-handler time limit (with the advantage of also catching sleeping/blocked queries)
  - Read-only enforcement via `default_transaction_read_only` and `conn.read_only` (with important caveats about soft vs. hard barriers)
  - Resource limits via server-side cursors, `temp_file_limit`, and `work_mem`
  - Privilege-based hard barriers via the GRANT system

- **pg_datasette_poc.py**: A `PostgresDatabase` class that reimplements Datasette's `Database.execute()` contract:
  - Async `execute()` method with `custom_time_limit` support
  - `Results` class matching Datasette's interface (rows, truncated, description)
  - `QueryInterrupted` exception for timeout/permission errors
  - Every connection pinned to `conn.read_only=True` and `statement_timeout`
  - Row truncation via `fetchmany()` to bound memory usage

- **README.md**: Detailed analysis comparing SQLite/Datasette vs PostgreSQL/psycopg safety models, including:
  - How each protection mechanism works in both systems
  - Key differences (e.g., read-only is soft in PostgreSQL, hard in SQLite)
  - Robust recipe for least-privilege PostgreSQL setup
  - Conclusion that PostgreSQL can match or exceed SQLite's safety guarantees

- **notes.md**: Investigation log documenting the discovery process, setup steps, and detailed findings from each experiment

- **experiments_output.txt** and **poc_output.txt**: Captured test runs demonstrating all protections working as expected

## Notable Implementation Details

- The hard read-only barrier in PostgreSQL comes from **least-privilege GRANTs** (SELECT only, no write grants, REVOKE TEMP/CREATE), not from the soft `default_transaction_read_only` flag
- `statement_timeout` is superior to SQLite's progress handler because it catches sleeping/blocked queries, not just CPU-bound work
- Server-side (named) cursors with `fetchmany()` provide the same memory-bounding guarantees as Datasette's client-side truncation
- PostgreSQL offers additional resource knobs (temp_file_limit, work_mem) that SQLite lacks

https://claude.ai/code/session_01SE5nF4qBFvcPvwTLhZt7MN